### PR TITLE
Configurable Benchmarks

### DIFF
--- a/tests/suite/CMakeLists.txt
+++ b/tests/suite/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(suite PRIVATE
   codec/timed/TimedTightEncoder.cxx
   codec/timed/TimedTightJPEGEncoder.cxx
   codec/timed/TimedZRLEEncoder.cxx
+  codec/timed/timedEncoderFactory.cxx
   io/FrameInStream.cxx
   streams/DummyInStream.cxx
   streams/DummyOutStream.cxx

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -6,6 +6,7 @@
 #include "codec/timed/TimedRawEncoder.h"
 #include "codec/timed/TimedTightJPEGEncoder.h"
 #include "codec/timed/TimedZRLEEncoder.h"
+#include "codec/timed/timedEncoderFactory.h"
 #include "rfb/EncodeManager.h"
 #include "rfb/Encoder.h"
 #include "rfb/SConnection.h"
@@ -15,7 +16,8 @@
 
 namespace suite {
 
-  Manager::Manager(rfb::SConnection *conn) : EncodeManager(conn)
+  Manager::Manager(rfb::SConnection *conn) : EncodeManager(conn),
+                                             SINGLE_ENCODER(false)
   {
     for(Encoder* encoder : encoders) {
       delete encoder;
@@ -34,25 +36,35 @@ namespace suite {
     }
   }
 
-  Manager::Manager(rfb::SConnection* conn, 
-                   std::array<rfb::Encoder*, ENCODERS_COUNT> encoders_) 
-                 : EncodeManager(conn)
+  Manager::Manager(rfb::SConnection* conn, EncoderSettings settings) 
+                                         : EncodeManager(conn),
+                                           SINGLE_ENCODER(true)
   {
     for (Encoder* e : encoders) {
       delete e;
     }
 
-    std::vector<Encoder*> encoders(std::begin(encoders_), std::end(encoders_));
-    this->encoders = encoders;
-
-    for (int i = 0; i < ENCODERS_COUNT; i++) {
-      TimedEncoder* timedEncoder = dynamic_cast<TimedEncoder*>(encoders[i]);
-      timedEncoders[timedEncoder->encoderClass] = timedEncoder;
+    EncoderClass encoderClass = settings.encoderClass;
+    TimedEncoder* timedEncoder = constructTimedEncoder(encoderClass, conn);
+    timedEncoders[encoderClass] = timedEncoder;
+    for (uint i = 0; i < ENCODERS_COUNT; i++) {
+      encoders[static_cast<EncoderClass>(i)] = 
+               dynamic_cast<Encoder*>(timedEncoder);
     }
   }
 
   Manager::~Manager()
   {
+    // Ugly hack, EncodeManager's destructor will call delete on all
+    // elements in encoders. Since we sometimes use the same pointer for
+    // all elements in encoders, we need to make sure there is something
+    // to be freed. 
+    if (SINGLE_ENCODER) {
+      for (uint i = 1; i < ENCODERS_COUNT; i++) {
+        encoders[i] = dynamic_cast<Encoder*>
+                      (constructTimedEncoder(encoderRaw, conn));
+      }
+    }
   }
 
   std::map<EncoderClass, encoderStats> Manager::stats() {

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -28,30 +28,21 @@ namespace suite {
     encoders[encoderTightJPEG] = new TimedTightJPEGEncoder(conn);
     encoders[encoderZRLE] = new TimedZRLEEncoder(conn);
 
+    for (uint i = 0; i < encoders.size(); i++) {
+      timedEncoders[static_cast<EncoderClass>(i)] = 
+              dynamic_cast<TimedEncoder*>(encoders[i]);
+    }
+  }
 
-    // Since Tight & TightJPEG share the same encode value (7), 
-    // we can't just loop through the encoders. We use EncoderClass as an 
-    // identifier instead of Encoder.encoding
-    timedEncoders[encoderRaw] =
-             dynamic_cast<TimedEncoder*>(encoders[encoderRaw]);
-    timedEncoders[encoderRRE] = 
-              dynamic_cast<TimedEncoder*>(encoders[encoderRRE]);
-    timedEncoders[encoderHextile] =
-              dynamic_cast<TimedEncoder*>(encoders[encoderHextile]);
-    timedEncoders[encoderTight] =
-              dynamic_cast<TimedEncoder*>(encoders[encoderTight]);
-    timedEncoders[encoderTightJPEG] = 
-              dynamic_cast<TimedEncoder*>(encoders[encoderTightJPEG]);
-    timedEncoders[encoderZRLE] =
-              dynamic_cast<TimedEncoder*>(encoders[encoderZRLE]);
+
   }
 
   Manager::~Manager()
   {
   }
 
-  std::map<const int, encoderStats> Manager::stats() {
-    std::map<const int, encoderStats> stats;
+  std::map<EncoderClass, encoderStats> Manager::stats() {
+    std::map<EncoderClass, encoderStats> stats;
     for(auto const& encoder : timedEncoders) {
       if (encoder.second->stats().writeRectEncodetime ||
           encoder.second->stats().writeSolidRectEncodetime)

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -34,7 +34,21 @@ namespace suite {
     }
   }
 
+  Manager::Manager(rfb::SConnection* conn, 
+                   std::array<rfb::Encoder*, ENCODERS_COUNT> encoders_) 
+                 : EncodeManager(conn)
+  {
+    for (Encoder* e : encoders) {
+      delete e;
+    }
 
+    std::vector<Encoder*> encoders(std::begin(encoders_), std::end(encoders_));
+    this->encoders = encoders;
+
+    for (int i = 0; i < ENCODERS_COUNT; i++) {
+      TimedEncoder* timedEncoder = dynamic_cast<TimedEncoder*>(encoders[i]);
+      timedEncoders[timedEncoder->encoderClass] = timedEncoder;
+    }
   }
 
   Manager::~Manager()

--- a/tests/suite/Manager.h
+++ b/tests/suite/Manager.h
@@ -63,13 +63,15 @@ namespace suite {
     {
     public:
       Manager(class rfb::SConnection *conn);
-      Manager(class rfb::SConnection *conn,
-              std::array<rfb::Encoder*, ENCODERS_COUNT> encoders);
+      // Creates an EncodingManager that only uses the specified Encoder
+      // for all encodings.
+      Manager(class rfb::SConnection *conn, EncoderSettings settings);
       ~Manager();
 
       std::map<EncoderClass, encoderStats> stats();
     protected:
       std::map<EncoderClass, TimedEncoder*> timedEncoders;
+      const bool SINGLE_ENCODER;
     };
 }
 #endif // __SUITE_MANAGER_H__

--- a/tests/suite/Manager.h
+++ b/tests/suite/Manager.h
@@ -7,9 +7,9 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <array>
 
 namespace suite {
-    
 
   using namespace enumEncoder;
 
@@ -57,10 +57,14 @@ namespace suite {
     return std::to_string(encoding);
   }
 
+    static const int ENCODERS_COUNT = 6;
+
     class Manager : public rfb::EncodeManager 
     {
     public:
       Manager(class rfb::SConnection *conn);
+      Manager(class rfb::SConnection *conn,
+              std::array<rfb::Encoder*, ENCODERS_COUNT> encoders);
       ~Manager();
 
       std::map<EncoderClass, encoderStats> stats();

--- a/tests/suite/Manager.h
+++ b/tests/suite/Manager.h
@@ -11,16 +11,7 @@
 namespace suite {
     
 
-  // Copied from EncodeManager.cxx
-  enum EncoderClass {
-    encoderRaw,
-    encoderRRE,
-    encoderHextile,
-    encoderTight,
-    encoderTightJPEG,
-    encoderZRLE,
-    encoderClassMax,
-  };
+  using namespace enumEncoder;
 
   // Copied from EncodeManager.cxx
   inline const char *encoderClassName(EncoderClass klass)
@@ -72,9 +63,9 @@ namespace suite {
       Manager(class rfb::SConnection *conn);
       ~Manager();
 
-      std::map<const int, encoderStats> stats();
+      std::map<EncoderClass, encoderStats> stats();
     protected:
-      std::map<const int, TimedEncoder*> timedEncoders;
+      std::map<EncoderClass, TimedEncoder*> timedEncoders;
     };
 }
 #endif // __SUITE_MANAGER_H__

--- a/tests/suite/Server.cxx
+++ b/tests/suite/Server.cxx
@@ -51,7 +51,7 @@ namespace suite {
   }
 
 
-  std::map<const int, encoderStats> Server::stats()
+  std::map<EncoderClass, encoderStats> Server::stats()
   {
     return manager->stats();
   }

--- a/tests/suite/Server.cxx
+++ b/tests/suite/Server.cxx
@@ -13,18 +13,11 @@ namespace suite {
     manager = new Manager(this);
   }
 
-  Server::Server(int width, int height, std::array<EncoderClass,
-                                                   ENCODERS_COUNT> encoders,
-                                                   rfb::PixelFormat pf)
+  Server::Server(int width, int height, EncoderSettings settings,
+                                        rfb::PixelFormat pf)
   {
-    auto encoders_ = std::array<rfb::Encoder*, ENCODERS_COUNT>();
-
-    for (int i = 0; i < ENCODERS_COUNT; i++) {
-      encoders_[i] = constructEncoder(encoders[i], this); 
-    }
-
     init(width, height, pf);
-    manager = new Manager(this, encoders_);
+    manager = new Manager(this, settings);
   }
 
   void Server::init(int width, int height, rfb::PixelFormat pf)

--- a/tests/suite/Server.cxx
+++ b/tests/suite/Server.cxx
@@ -1,4 +1,8 @@
 #include "Server.h"
+#include "Manager.h"
+#include "codec/timed/TimedEncoder.h"
+#include "codec/timed/timedEncoderFactory.h"
+#include "rfb/SConnection.h"
 #include "rfb/SMsgWriter.h"
 
 namespace suite {
@@ -9,12 +13,18 @@ namespace suite {
     manager = new Manager(this);
   }
 
-  Server::Server(int width, int height, std::array<rfb::Encoder*,
+  Server::Server(int width, int height, std::array<EncoderClass,
                                                    ENCODERS_COUNT> encoders,
                                                    rfb::PixelFormat pf)
   {
+    auto encoders_ = std::array<rfb::Encoder*, ENCODERS_COUNT>();
+
+    for (int i = 0; i < ENCODERS_COUNT; i++) {
+      encoders_[i] = constructEncoder(encoders[i], this); 
+    }
+
     init(width, height, pf);
-    manager = new Manager(this, encoders);
+    manager = new Manager(this, encoders_);
   }
 
   void Server::init(int width, int height, rfb::PixelFormat pf)

--- a/tests/suite/Server.cxx
+++ b/tests/suite/Server.cxx
@@ -5,12 +5,25 @@ namespace suite {
 
   Server::Server(int width, int height, rfb::PixelFormat pf)
   {
+    init(width, height, pf);
+    manager = new Manager(this);
+  }
+
+  Server::Server(int width, int height, std::array<rfb::Encoder*,
+                                                   ENCODERS_COUNT> encoders,
+                                                   rfb::PixelFormat pf)
+  {
+    init(width, height, pf);
+    manager = new Manager(this, encoders);
+  }
+
+  void Server::init(int width, int height, rfb::PixelFormat pf)
+  {
     out = new DummyOutStream();
     in = new DummyInStream();
     setStreams(in, out);
     setWriter(new rfb::SMsgWriter(&client, out));
 
-    manager = new Manager(this);
     this->updates = rfb::SimpleUpdateTracker();
 
     setPixelFormat(fbPF);

--- a/tests/suite/Server.h
+++ b/tests/suite/Server.h
@@ -26,8 +26,7 @@ namespace suite {
     {
     public:
       Server(int width, int height, rfb::PixelFormat pf = fbPF);
-      Server(int width, int height, std::array<EncoderClass,
-                                               ENCODERS_COUNT> encoders,
+      Server(int width, int height, EncoderSettings settings,
                                     rfb::PixelFormat pf = fbPF);
       ~Server();
 

--- a/tests/suite/Server.h
+++ b/tests/suite/Server.h
@@ -34,7 +34,7 @@ namespace suite {
       // Loads an Image onto the framebuffer at x, y
       virtual void loadImage(Image* image, int x = 0, int y = 0);
 
-      std::map<const int, encoderStats> stats();
+      std::map<EncoderClass, encoderStats> stats();
     public:
       DummyInStream *in;
       DummyOutStream *out;

--- a/tests/suite/Server.h
+++ b/tests/suite/Server.h
@@ -1,5 +1,6 @@
 #ifndef __SUITE_SERVER_H__
 #define __SUITE_SERVER_H__
+#include "rfb/PixelFormat.h"
 #include "streams/DummyInStream.h"
 #include "streams/DummyOutStream.h"
 #include "codec/Image.h"
@@ -24,6 +25,9 @@ namespace suite {
     {
     public:
       Server(int width, int height, rfb::PixelFormat pf = fbPF);
+      Server(int width, int height, std::array<rfb::Encoder*,
+                                               ENCODERS_COUNT> encoders,
+                                    rfb::PixelFormat pf = fbPF);
       ~Server();
 
       void writeUpdate(const rfb::UpdateInfo& ui, const rfb::PixelBuffer* pb);
@@ -42,6 +46,7 @@ namespace suite {
       Manager *manager;
       rfb::SimpleUpdateTracker updates;
       rfb::ManagedPixelBuffer* pb;
+      void init(int width, int height, rfb::PixelFormat pf);
     };
 
   }

--- a/tests/suite/Server.h
+++ b/tests/suite/Server.h
@@ -1,5 +1,6 @@
 #ifndef __SUITE_SERVER_H__
 #define __SUITE_SERVER_H__
+#include "codec/timed/TimedEncoder.h"
 #include "rfb/PixelFormat.h"
 #include "streams/DummyInStream.h"
 #include "streams/DummyOutStream.h"
@@ -25,7 +26,7 @@ namespace suite {
     {
     public:
       Server(int width, int height, rfb::PixelFormat pf = fbPF);
-      Server(int width, int height, std::array<rfb::Encoder*,
+      Server(int width, int height, std::array<EncoderClass,
                                                ENCODERS_COUNT> encoders,
                                     rfb::PixelFormat pf = fbPF);
       ~Server();

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -96,7 +96,7 @@ void Benchmark::runBenchmark()
     std::cout << "Encoder set: " << encoderRequested << ".\n"
               << "\tEncoder(s) used:\n";
     double totalEncodingtime = 0;
-    int tableWidth = 30;
+    int tableWidth = 35;
     int precision = 5;
     for(const auto& es : encoderStats) {
        struct encoderStats stats = es.second;
@@ -123,7 +123,19 @@ void Benchmark::runBenchmark()
                   << std::setw(tableWidth+precision+2)
                   << std::left << "" << std::setfill(' ')
                   << "\n\t\t\t" << std::setw(tableWidth) << std::left
-                  << "Compression ratio rects: " << std::right
+                  << "MPx/s (rects):" << std::right 
+                  << stats.megaPixelsPerSecondRects() << "\n\t\t\t"
+                  << std::setw(tableWidth) << std::left
+                  << "MPx/s (solidRects:)" << std::right 
+                  << stats.megaPixelsPerSecondSolidRects() << "\n\t\t\t"
+                  << std::setw(tableWidth) << std::left 
+                  << "MPx/s (combined)" << std::right
+                  << stats.megaPixelsPerSecondCombined() << "\n\t\t\t"
+                  << std::setfill('-') 
+                  << std::setw(tableWidth+precision+2)
+                  << std::left << "" << std::setfill(' ') << "\n\t\t\t"
+                  << std::setw(tableWidth) << std::left
+                  << "Compression ratio rects: "
                   << stats.compressionRatioRects()
                   << "\n\t\t\t" << std::setw(tableWidth) << std::left
                   << "Compression ratio solidRects: " << std::right 

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -95,7 +95,6 @@ void Benchmark::runBenchmark()
 
     std::cout << "Encoder set: " << encoderRequested << ".\n"
               << "\tEncoder(s) used:\n";
-    double totalEncodingtime = 0;
     int tableWidth = 35;
     int precision = 5;
     for(const auto& es : encoderStats) {
@@ -147,16 +146,13 @@ void Benchmark::runBenchmark()
                   << std::setw(tableWidth+precision+2)
                   << std::left << "" << std::setfill(' ') << "\n\t\t\t"
                   << std::setw(tableWidth) << std::left
-                  << "Score (time * compression ratio):" << std::right << stats.score() << "\n\t\t\t"
-                  << std::setfill('-')  << std::setw(tableWidth+precision+2)
+                  << "Score (time * compression ratio):" << std::right
+                  << stats.score() << "\n\t\t\t" << std::setfill('-') 
+                  << std::setw(tableWidth+precision+2)
                   << std::left << "" << std::endl;
 
-
-      totalEncodingtime += stats.writeRectEncodetime 
-                         + stats.writeSolidRectEncodetime;
     }
 
-  if(totalEncodingtime) {} // FIXME: use this value...
   delete server;
   }
 }

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -96,27 +96,44 @@ void Benchmark::runBenchmark()
     std::cout << "Encoder set: " << encoderRequested << ".\n"
               << "\tEncoder(s) used:\n";
     double totalEncodingtime = 0;
-    int tableWidth = 20;
+    int tableWidth = 30;
+    int precision = 5;
     for(const auto& es : encoderStats) {
        struct encoderStats stats = es.second;
 
-        std::cout << "\t\t" << stats.name << " encoder: (seconds)\n\t\t\t"
-                  << std::setprecision(5) << std::fixed 
+        // FIXME: Wrap this monstrosity in smaller functions :^)
+        std::cout << "\n\t\t" << stats.name << " encoder: (seconds)\n\t\t\t"
+                  << std::setprecision(precision) << std::fixed 
                   << std::setw(tableWidth) << std::setfill(' ') << std::left
                   << "writeRect: " << std::right << stats.writeRectEncodetime
                   << "\n\t\t\t" << std::left  << std::setw(tableWidth)
                   << "writeSolidRect: " << std::right 
-                  << (stats.writeSolidRectEncodetime != 0 ? 
-                        std::to_string(stats.writeSolidRectEncodetime)
-                            : "-" ) // FIXME: the string is 1 char too long
-                  << "\n\t\t\t"
-                  << std::setw(tableWidth) << std::left
+                  << stats.compressionRatioSolidRects()
+                  << "\n\t\t\t" << std::setw(tableWidth) << std::left
                   << "total: " << std::right << stats.writeRectEncodetime 
                                               + stats.writeSolidRectEncodetime
-                    << "\n\t\t\t" << std::setw(tableWidth) << std::left 
-                    << "Compression ratio: " << std::right
-                    <<  stats.outputSize / (double) stats.inputSize 
-                    << std::endl;
+                  << "\n\t\t\t" << std::setfill('-')
+                  << std::setw(tableWidth+precision+2)
+                  << std::left << "" << std::setfill(' ')
+                  << "\n\t\t\t" << std::setw(tableWidth) << std::left  
+                  << "# rects: " << std::right << stats.nRects
+                  << "\n\t\t\t" << std::setw(tableWidth) << std::left
+                  << "# solidRects: " << std::right << stats.nSolidRects 
+                  << "\n\t\t\t" << std::setfill('-') 
+                  << std::setw(tableWidth+precision+2)
+                  << std::left << "" << std::setfill(' ')
+                  << "\n\t\t\t" << std::setw(tableWidth) << std::left
+                  << "Compression ratio rects: " << std::right
+                  << stats.compressionRatioRects()
+                  << "\n\t\t\t" << std::setw(tableWidth) << std::left
+                  << "Compression ratio solidRects: " << std::right 
+                  << stats.compressionRatioSolidRects() << "\n\t\t\t"
+                  << std::setw(tableWidth) << std::left
+                  << "Compression ratio combined: " 
+                  << stats.compressionRatioCombined() << "\n\t\t\t"
+                  << std::setfill('-') << std::setw(tableWidth)
+                  << std::setw(tableWidth+precision+2)
+                  << std::left << "" << std::setfill(' ') << "\n";
 
       totalEncodingtime += stats.writeRectEncodetime 
                          + stats.writeSolidRectEncodetime;

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -88,7 +88,7 @@ void Benchmark::runBenchmark()
     // FIXME: Refactor this to a separate function
     std::string encoderRequested = encodingToString(s.first);
     Server* server = s.second;
-    std::map<const int, encoderStats> encoderStats = server->stats();
+    std::map<EncoderClass, encoderStats> encoderStats = server->stats();
 
     if(!encoderStats.size())
       continue; // FIXME: throw/log error?

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -156,3 +156,41 @@ void Benchmark::runBenchmark()
   delete server;
   }
 }
+
+EncoderSettings Benchmark::encoderSettings(EncoderClass encoderClass,
+                                           PseudoEncodingLevel quality,
+                                           PseudoEncodingLevel compression)
+{
+  EncoderSettings settings {
+    .encoderClass = encoderClass,
+    .rfbEncoding = rfb::encodingRaw,
+    .quality = quality,
+    .compression = compression,
+  };
+
+  switch(encoderClass) {
+      case encoderRaw:
+        settings.rfbEncoding = rfb::encodingRaw;
+        break;
+      case encoderRRE:
+        settings.rfbEncoding = rfb::encodingRRE;
+        break;
+      case encoderHextile:
+        settings.rfbEncoding = rfb::encodingHextile;
+        break;
+      case encoderTight:
+        settings.rfbEncoding = rfb::encodingTight;
+        break;
+      case encoderTightJPEG:
+        if (quality == NONE)
+          settings.quality = TWO;
+        settings.rfbEncoding = rfb::encodingTight;
+        break;
+      case encoderZRLE:
+        settings.rfbEncoding = rfb::encodingZRLE;
+        break;
+      default:
+        throw std::logic_error("EncoderClass not implemented");
+  }
+  return settings;
+}

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -145,7 +145,12 @@ void Benchmark::runBenchmark()
                   << stats.compressionRatioCombined() << "\n\t\t\t"
                   << std::setfill('-') << std::setw(tableWidth)
                   << std::setw(tableWidth+precision+2)
-                  << std::left << "" << std::setfill(' ') << "\n";
+                  << std::left << "" << std::setfill(' ') << "\n\t\t\t"
+                  << std::setw(tableWidth) << std::left
+                  << "Score (time * compression ratio):" << std::right << stats.score() << "\n\t\t\t"
+                  << std::setfill('-')  << std::setw(tableWidth+precision+2)
+                  << std::left << "" << std::endl;
+
 
       totalEncodingtime += stats.writeRectEncodetime 
                          + stats.writeSolidRectEncodetime;

--- a/tests/suite/benchmark/Benchmark.h
+++ b/tests/suite/benchmark/Benchmark.h
@@ -30,6 +30,9 @@ namespace suite {
   private:
     const rdr::S32* encodings_;
     const size_t encodingsLength_;
+    static EncoderSettings encoderSettings(EncoderClass encoderClass, 
+                                        PseudoEncodingLevel quality = NONE,
+                                        PseudoEncodingLevel compression = TWO);
   };
 }
 #endif // __SUITE_BENCHMARK_H__

--- a/tests/suite/benchmark/Benchmark.h
+++ b/tests/suite/benchmark/Benchmark.h
@@ -17,6 +17,8 @@ namespace suite {
     ~Benchmark();
 
     // Runs decoding benchmark on the server.
+    void runBenchmark(EncoderSettings* settings, size_t len);
+    // Default benchmark runs each encoder once (ENCODERS_COUNT in total)
     void runBenchmark();
     int width() const { return width_; }
     int height() const { return height_; }

--- a/tests/suite/codec/timed/TimedEncoder.cxx
+++ b/tests/suite/codec/timed/TimedEncoder.cxx
@@ -2,11 +2,13 @@
 #include "rdr/MemOutStream.h"
 #include "rfb/PixelBuffer.h"
 #include "rfb/SConnection.h"
+#include "../../Manager.h"
 #include <chrono>
 
 namespace suite {
 
-  TimedEncoder::TimedEncoder(std::string name)
+  TimedEncoder::TimedEncoder(EncoderClass encoderclass) 
+                           : encoderClass(encoderclass)
   {
     stats_ = encoderStats{ 
       .writeRectEncodetime = 0,
@@ -17,7 +19,7 @@ namespace suite {
       .outputSizeSolidRects = 0,
       .nRects = 0,
       .nSolidRects = 0,
-      .name = name,
+      .name = encoderClassName(encoderclass),
       };
     // Use an OutStream and inject it to the underlying 
     // SConn just before writeRect() and writeSolidRect()

--- a/tests/suite/codec/timed/TimedEncoder.cxx
+++ b/tests/suite/codec/timed/TimedEncoder.cxx
@@ -11,8 +11,12 @@ namespace suite {
     stats_ = encoderStats{ 
       .writeRectEncodetime = 0,
       .writeSolidRectEncodetime = 0,
-      .inputSize = 0,
-      .outputSize = 0,
+      .inputSizeRects = 0,
+      .outputSizeRects = 0,
+      .inputSizeSolidRects = 0,
+      .outputSizeSolidRects = 0,
+      .nRects = 0,
+      .nSolidRects = 0,
       .name = name,
       };
     // Use an OutStream and inject it to the underlying 
@@ -43,8 +47,9 @@ namespace suite {
     std::chrono::duration<double> time = now - writeRectStart;
 
     stats_.writeRectEncodetime += time.count();
-    stats_.inputSize += pb->width() * pb->height() * 4;
-    stats_.outputSize += encoderOutstream->length();
+    stats_.inputSizeRects += pb->width() * pb->height() * 4;
+    stats_.outputSizeRects += encoderOutstream->length();
+    stats_.nRects++;
 
     // Return the original OutStream after encoding
     // & reset our MemOutStream
@@ -68,8 +73,9 @@ namespace suite {
     std::chrono::duration<double> time = now - writeSolidRectStart;
 
     stats_.writeSolidRectEncodetime += time.count();
-    stats_.inputSize += width * height * 4;
-    stats_.outputSize += encoderOutstream->length();
+    stats_.inputSizeSolidRects += width * height * 4;
+    stats_.outputSizeSolidRects += encoderOutstream->length();
+    stats_.nSolidRects++;
 
     // Return the original OutStream after encoding
     // & reset our MemOutStream

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -119,7 +119,7 @@ namespace suite {
     }
   };
 
-  class TimedEncoder 
+  class TimedEncoder
   {
   public:
     TimedEncoder(EncoderClass encoderclass);
@@ -131,6 +131,12 @@ namespace suite {
     void stopWriteSolidRectTimer(int width, int height);
     const EncoderClass encoderClass;
     encoderStats stats() { return stats_; };
+    virtual bool isSupported() { return true; };
+    virtual void writeRect(const rfb::PixelBuffer* pb,
+                           const rfb::Palette& palette)=0;
+    virtual void writeSolidRect(int width, int height,
+                                const rfb::PixelFormat& pf,
+                                const rdr::U8* colour)=0;
   private:
     rdr::MemOutStream *encoderOutstream;
     rdr::OutStream* os;

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -68,6 +68,13 @@ namespace suite {
            / ((writeRectEncodetime + writeSolidRectEncodetime) * 10e6);
     }
 
+    // Returns a "score" which is a function of time 
+    // per compressed data
+    double score()
+    {
+      return (writeRectEncodetime + writeSolidRectEncodetime)
+           * (compressionRatioCombined());
+    }
   };
 
   class TimedEncoder 

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -37,6 +37,23 @@ namespace suite {
       return (double) (outputSizeRects + outputSizeSolidRects)
                     / (inputSizeRects + inputSizeSolidRects);
     }
+
+    double megaPixelsPerSecondRects()
+    {
+      return inputSizeRects / (writeRectEncodetime * 10e6);
+    }
+  
+    double megaPixelsPerSecondSolidRects()
+    {
+      return inputSizeSolidRects / (writeSolidRectEncodetime * 10e6);
+    }
+
+    double megaPixelsPerSecondCombined()
+    {
+      return (inputSizeRects + inputSizeSolidRects) 
+           / ((writeRectEncodetime + writeSolidRectEncodetime) * 10e6);
+    }
+
   };
 
   class TimedEncoder 

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -14,9 +14,29 @@ namespace suite {
   struct encoderStats {
     double writeRectEncodetime;
     double writeSolidRectEncodetime;
-    int inputSize;
-    int outputSize;
+    int inputSizeRects;
+    int outputSizeRects;
+    int inputSizeSolidRects;
+    int outputSizeSolidRects;
+    int nRects;
+    int nSolidRects;
     std::string name;
+
+    double compressionRatioRects() 
+    {
+      return (double) outputSizeRects / inputSizeRects; 
+    }
+
+    double compressionRatioSolidRects()
+    {
+       return (double) outputSizeSolidRects / inputSizeSolidRects;
+    }
+
+    double compressionRatioCombined()
+    {
+      return (double) (outputSizeRects + outputSizeSolidRects)
+                    / (inputSizeRects + inputSizeSolidRects);
+    }
   };
 
   class TimedEncoder 

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -131,12 +131,11 @@ namespace suite {
     void stopWriteSolidRectTimer(int width, int height);
     const EncoderClass encoderClass;
     encoderStats stats() { return stats_; };
-  protected:
+  private:
     rdr::MemOutStream *encoderOutstream;
     rdr::OutStream* os;
     rdr::InStream* is;
     rfb::SConnection* conn_;
-  private:
     encoderStats stats_;
     std::chrono::system_clock::time_point writeRectStart;
     std::chrono::system_clock::time_point writeSolidRectStart;

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -8,6 +8,7 @@
 #include "rfb/PixelBuffer.h"
 #include "rfb/SConnection.h"
 #include <chrono>
+#include <stdexcept>
 #include <string>
 namespace suite {
 
@@ -22,6 +23,47 @@ namespace suite {
       encoderZRLE,
       encoderClassMax,
     };
+
+    enum PseudoEncodingLevel {
+      NONE = -1,
+      ZERO,
+      ONE,
+      TWO,
+      THREE,
+      FOUR,
+      FIVE,
+      SIX,
+      SEVEN,
+      EIGHT,
+      NINE
+    };
+
+    struct EncoderSettings {
+      EncoderClass encoderClass;
+      int rfbEncoding;
+      PseudoEncodingLevel quality;
+      PseudoEncodingLevel compression;
+    };
+
+    inline std::string encoderClasstoString(EncoderClass encoderClass)
+    {
+      switch (encoderClass) {
+        case encoderRaw:
+          return "Raw";
+        case encoderRRE:
+          return "RRE";
+        case encoderHextile:
+          return "Hextile";
+        case encoderTight:
+          return "Tight";
+        case encoderTightJPEG:
+          return "TightJPEG";
+        case encoderZRLE:
+          return "ZRLE";
+        default:
+          throw std::logic_error("EncoderClass not implemented");
+      }
+    }
   }
   using namespace enumEncoder;
 

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -11,6 +11,20 @@
 #include <string>
 namespace suite {
 
+    // Copied from EncodeManager.cxx
+  namespace enumEncoder {
+    enum EncoderClass {
+      encoderRaw,
+      encoderRRE,
+      encoderHextile,
+      encoderTight,
+      encoderTightJPEG,
+      encoderZRLE,
+      encoderClassMax,
+    };
+  }
+  using namespace enumEncoder;
+
   struct encoderStats {
     double writeRectEncodetime;
     double writeSolidRectEncodetime;
@@ -59,13 +73,14 @@ namespace suite {
   class TimedEncoder 
   {
   public:
-    TimedEncoder(std::string name);
+    TimedEncoder(EncoderClass encoderclass);
     ~TimedEncoder();
 
     void startWriteRectTimer(rfb::SConnection* sconn);
     void stopWriteRectTimer(const rfb::PixelBuffer* pb);
     void startWriteSolidRectTimer(rfb::SConnection* sconn);
     void stopWriteSolidRectTimer(int width, int height);
+    const EncoderClass encoderClass;
     encoderStats stats() { return stats_; };
   protected:
     rdr::MemOutStream *encoderOutstream;

--- a/tests/suite/codec/timed/TimedHextileEncoder.cxx
+++ b/tests/suite/codec/timed/TimedHextileEncoder.cxx
@@ -1,14 +1,13 @@
 #include "TimedHextileEncoder.h"
 #include "TimedEncoder.h"
 #include "rfb/SConnection.h"
-#include "../../Manager.h"
 #include <iostream>
 
 namespace suite {
 
   TimedHextileEncoder::TimedHextileEncoder(SConnection* conn_) 
                               : HextileEncoder(conn_), 
-                                TimedEncoder(encoderClassName(encoderHextile))
+                                TimedEncoder(encoderHextile)
   {
     os = conn->getOutStream();
     is = conn->getInStream();

--- a/tests/suite/codec/timed/TimedHextileEncoder.cxx
+++ b/tests/suite/codec/timed/TimedHextileEncoder.cxx
@@ -9,9 +9,6 @@ namespace suite {
                               : HextileEncoder(conn_), 
                                 TimedEncoder(encoderHextile)
   {
-    os = conn->getOutStream();
-    is = conn->getInStream();
-    conn_ = conn;
   }
 
   TimedHextileEncoder::~TimedHextileEncoder()

--- a/tests/suite/codec/timed/TimedRREEncoder.cxx
+++ b/tests/suite/codec/timed/TimedRREEncoder.cxx
@@ -1,14 +1,12 @@
 #include "TimedRREEncoder.h"
 #include "TimedEncoder.h"
 #include "rfb/SConnection.h"
-#include "../../Manager.h"
 #include <iostream>
 
 namespace suite {
 
   TimedRREEncoder::TimedRREEncoder(SConnection* conn_) 
-                                  : RREEncoder(conn_),
-                                    TimedEncoder(encoderClassName(encoderRRE))
+                                  : RREEncoder(conn_), TimedEncoder(encoderRRE)
   {
     os = conn->getOutStream();
     is = conn->getInStream();

--- a/tests/suite/codec/timed/TimedRREEncoder.cxx
+++ b/tests/suite/codec/timed/TimedRREEncoder.cxx
@@ -6,11 +6,9 @@
 namespace suite {
 
   TimedRREEncoder::TimedRREEncoder(SConnection* conn_) 
-                                  : RREEncoder(conn_), TimedEncoder(encoderRRE)
+                                  : RREEncoder(conn_),
+                                    TimedEncoder(encoderRRE)
   {
-    os = conn->getOutStream();
-    is = conn->getInStream();
-    conn_ = conn;
   }
 
   TimedRREEncoder::~TimedRREEncoder()

--- a/tests/suite/codec/timed/TimedRawEncoder.cxx
+++ b/tests/suite/codec/timed/TimedRawEncoder.cxx
@@ -8,7 +8,6 @@ namespace suite {
   TimedRawEncoder::TimedRawEncoder(SConnection* conn_) 
                                  : RawEncoder(conn_), TimedEncoder(encoderRaw)
   {
-    conn_ = conn;
   }
 
   TimedRawEncoder::~TimedRawEncoder()

--- a/tests/suite/codec/timed/TimedRawEncoder.cxx
+++ b/tests/suite/codec/timed/TimedRawEncoder.cxx
@@ -1,14 +1,12 @@
 #include "TimedRawEncoder.h"
 #include "TimedEncoder.h"
 #include "rfb/SConnection.h"
-#include "../../Manager.h"
 #include <iostream>
 
 namespace suite {
 
   TimedRawEncoder::TimedRawEncoder(SConnection* conn_) 
-                                 : RawEncoder(conn_),
-                                   TimedEncoder(encoderClassName(encoderRaw))
+                                 : RawEncoder(conn_), TimedEncoder(encoderRaw)
   {
     conn_ = conn;
   }

--- a/tests/suite/codec/timed/TimedTightEncoder.cxx
+++ b/tests/suite/codec/timed/TimedTightEncoder.cxx
@@ -12,9 +12,6 @@ namespace suite {
                                 : TightEncoder(conn_), 
                                   TimedEncoder(encoderTight)
   {
-    os = conn->getOutStream();
-    is = conn->getInStream();
-    conn_ = conn;
   }
 
   TimedTightEncoder::~TimedTightEncoder()

--- a/tests/suite/codec/timed/TimedTightEncoder.cxx
+++ b/tests/suite/codec/timed/TimedTightEncoder.cxx
@@ -4,14 +4,13 @@
 #include "rdr/MemOutStream.h"
 #include "rdr/OutStream.h"
 #include "rfb/SConnection.h"
-#include "../../Manager.h"
 #include <iostream>
 
 namespace suite {
 
   TimedTightEncoder::TimedTightEncoder(SConnection* conn_) 
-                                : TightEncoder(conn_),
-                                  TimedEncoder(encoderClassName(encoderTight))
+                                : TightEncoder(conn_), 
+                                  TimedEncoder(encoderTight)
   {
     os = conn->getOutStream();
     is = conn->getInStream();

--- a/tests/suite/codec/timed/TimedTightJPEGEncoder.cxx
+++ b/tests/suite/codec/timed/TimedTightJPEGEncoder.cxx
@@ -9,9 +9,6 @@ namespace suite {
                             : TightJPEGEncoder(conn_), 
                               TimedEncoder(encoderTightJPEG)
   {
-    os = conn->getOutStream();
-    is = conn->getInStream();
-    conn_ = conn;
   }
 
   TimedTightJPEGEncoder::~TimedTightJPEGEncoder()

--- a/tests/suite/codec/timed/TimedTightJPEGEncoder.cxx
+++ b/tests/suite/codec/timed/TimedTightJPEGEncoder.cxx
@@ -1,14 +1,13 @@
 #include "TimedTightJPEGEncoder.h"
 #include "TimedEncoder.h"
 #include "rfb/SConnection.h"
-#include "../../Manager.h"
 #include <iostream>
 
 namespace suite {
 
   TimedTightJPEGEncoder::TimedTightJPEGEncoder(SConnection* conn_) 
                             : TightJPEGEncoder(conn_), 
-                              TimedEncoder(encoderClassName(encoderTightJPEG))
+                              TimedEncoder(encoderTightJPEG)
   {
     os = conn->getOutStream();
     is = conn->getInStream();

--- a/tests/suite/codec/timed/TimedZRLEEncoder.cxx
+++ b/tests/suite/codec/timed/TimedZRLEEncoder.cxx
@@ -9,9 +9,6 @@ namespace suite {
                                   : ZRLEEncoder(conn_), 
                                     TimedEncoder(encoderZRLE)
   {
-    os = conn->getOutStream();
-    is = conn->getInStream();
-    conn_ = conn;
   }
 
   TimedZRLEEncoder::~TimedZRLEEncoder()

--- a/tests/suite/codec/timed/TimedZRLEEncoder.cxx
+++ b/tests/suite/codec/timed/TimedZRLEEncoder.cxx
@@ -1,14 +1,13 @@
 #include "TimedZRLEEncoder.h"
 #include "TimedEncoder.h"
 #include "rfb/SConnection.h"
-#include "../../Manager.h"
 #include <iostream>
 
 namespace suite {
 
   TimedZRLEEncoder::TimedZRLEEncoder(SConnection* conn_) 
-                                  : ZRLEEncoder(conn_),
-                                    TimedEncoder(encoderClassName(encoderZRLE))
+                                  : ZRLEEncoder(conn_), 
+                                    TimedEncoder(encoderZRLE)
   {
     os = conn->getOutStream();
     is = conn->getInStream();

--- a/tests/suite/codec/timed/timedEncoderFactory.cxx
+++ b/tests/suite/codec/timed/timedEncoderFactory.cxx
@@ -9,11 +9,11 @@
 #include <stdexcept>
 
 namespace suite {
-  rfb::Encoder* constructEncoder(EncoderClass encoder, rfb::SConnection* sconn)
+  TimedEncoder* constructTimedEncoder(EncoderClass encoder, rfb::SConnection* sconn)
   {
     switch(encoder) {
       case encoderRaw:
-        return new TimedRawEncoder(sconn);  
+        return new TimedRawEncoder(sconn);
       case encoderRRE:
         return new TimedRREEncoder(sconn);
       case encoderHextile:

--- a/tests/suite/codec/timed/timedEncoderFactory.cxx
+++ b/tests/suite/codec/timed/timedEncoderFactory.cxx
@@ -1,0 +1,31 @@
+#include "timedEncoderFactory.h"
+#include "TimedRawEncoder.h"
+#include "TimedRREEncoder.h"
+#include "TimedHextileEncoder.h"
+#include "TimedTightEncoder.h"
+#include "TimedTightJPEGEncoder.h"
+#include "TimedZRLEEncoder.h"
+#include "rfb/SConnection.h"
+#include <stdexcept>
+
+namespace suite {
+  rfb::Encoder* constructEncoder(EncoderClass encoder, rfb::SConnection* sconn)
+  {
+    switch(encoder) {
+      case encoderRaw:
+        return new TimedRawEncoder(sconn);  
+      case encoderRRE:
+        return new TimedRREEncoder(sconn);
+      case encoderHextile:
+        return new TimedHextileEncoder(sconn);
+      case encoderTight:
+        return new TimedTightEncoder(sconn);
+      case encoderTightJPEG:
+        return new TimedTightJPEGEncoder(sconn);
+      case encoderZRLE:
+        return new TimedZRLEEncoder(sconn);
+      default:
+        throw std::logic_error("decoder not implemented");
+    }
+  }
+}

--- a/tests/suite/codec/timed/timedEncoderFactory.h
+++ b/tests/suite/codec/timed/timedEncoderFactory.h
@@ -5,7 +5,7 @@
 #include "rfb/SConnection.h"
 
 namespace suite {
-  rfb::Encoder* constructEncoder(EncoderClass encoder, rfb::SConnection* conn);
+  TimedEncoder* constructTimedEncoder(EncoderClass encoder, rfb::SConnection* conn);
 }
 
 #endif // __SUITE_TIMEDENCODERFACTORY_H__

--- a/tests/suite/codec/timed/timedEncoderFactory.h
+++ b/tests/suite/codec/timed/timedEncoderFactory.h
@@ -1,0 +1,11 @@
+#ifndef __SUITE_TIMEDENCODERFACTORY_H__
+#define __SUITE_TIMEDENCODERFACTORY_H__
+
+#include "TimedEncoder.h"
+#include "rfb/SConnection.h"
+
+namespace suite {
+  rfb::Encoder* constructEncoder(EncoderClass encoder, rfb::SConnection* conn);
+}
+
+#endif // __SUITE_TIMEDENCODERFACTORY_H__

--- a/tests/suite/io/FrameInStream.cxx
+++ b/tests/suite/io/FrameInStream.cxx
@@ -17,6 +17,7 @@ namespace suite {
 
   FrameInStream::~FrameInStream()
   {
+    delete decoder;
   }
 
   Image* FrameInStream::readImage(std::istream& is)


### PR DESCRIPTION
This PR makes it possible to run benchmarks where you can specify which encoder(s) to use. For each encoder, the following stats are output: 

* time taken by `writeRect()`.
* time taken by `writeSolidRect()`.
* time taken in total.
* Number of rects.
* Number of solidRects.
* MPx/s encoding rects.
* MPx/s encoding solidRects.
* MPx/s encoding in total.
* Compression ratio rects.
* Compression ratio solidRects.
* Compression ratio in total.
* Score (time * compression ratio).

Score isn't a good metric at all, and I might play around to see if there is that can be said here that is a better indicator than just MPx/s.