### PR TITLE
More Benchmark statistics

### DIFF
--- a/tests/suite/CMakeLists.txt
+++ b/tests/suite/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(${CMAKE_SOURCE_DIR}/common)
+include_directories(${CMAKE_SOURCE_DIR}/common/os)
 include_directories(${CMAKE_SOURCE_DIR}/unix)
+include_directories(${CMAKE_SOURCE_DIR}/unix/common)
 include_directories(${X11_INCLUDE_DIR})
 include_directories(${FLTK_INCLUDE_DIR})
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
@@ -10,6 +12,13 @@ target_sources(suite PRIVATE
   Manager.cxx
   Server.cxx
   Client.cxx
+  TestWindow.cxx
+  ../../vncviewer/PlatformPixelBuffer.cxx
+  ../../vncviewer/Surface.cxx
+  ../../vncviewer/Surface_X11.cxx
+  #../../unix/xserver/hw/vnc/XserverDesktop.cc
+  #../../unix/xserver/hw/vnc/vncBlockHandler.c
+  #../../common/os/os.cxx
   benchmark/Benchmark.cxx
   codec/PPMDecoder.cxx
   codec/PNGDecoder.cxx
@@ -26,13 +35,19 @@ target_sources(suite PRIVATE
   codec/timed/TimedTightJPEGEncoder.cxx
   codec/timed/TimedZRLEEncoder.cxx
   codec/timed/timedEncoderFactory.cxx
+  codec/timed/encoderStats.h
   io/FrameInStream.cxx
   streams/DummyInStream.cxx
   streams/DummyOutStream.cxx
 )
 
-target_link_libraries(suite rfb)
+target_link_libraries(suite rfb ${FLTK_LIBRARIES})
 target_compile_features(suite PRIVATE cxx_std_11)
+
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(MyTarget PUBLIC OpenMP::OpenMP_CXX)
+endif()
 
 # Recording tool
 add_subdirectory(recorder)

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -92,6 +92,10 @@ namespace suite {
       .timeSpent = time.count() * 10e2,
     };
     timedEncoder_->addWriteUpdate(data);
+
+    // Increment the currentWriteUpdate index so we can keep track
+    // of which writeRect() belongs to which writeUpdate.
+    timedEncoder_->currentWriteUpdate++;
   }
 
   std::map<EncoderClass, encoderStats> Manager::stats() {

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -89,7 +89,7 @@ namespace suite {
     // (as it was recorded).
     writeUpdateStats data {
       .timeRequired = frameTime,
-      .timeSpent = (uint) (time.count() * 10e2),
+      .timeSpent = time.count() * 10e2,
     };
     timedEncoder_->addWriteUpdate(data);
   }

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -89,7 +89,7 @@ namespace suite {
     // (as it was recorded).
     writeUpdateStats data {
       .timeRequired = frameTime,
-      .timeSpent = (uint) (time.count() * 10e3),
+      .timeSpent = (uint) (time.count() * 10e2),
     };
     timedEncoder_->addWriteUpdate(data);
   }

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -20,9 +20,8 @@ namespace suite {
   Manager::Manager(rfb::SConnection *conn) : EncodeManager(conn),
                                              SINGLE_ENCODER(false)
   {
-    for(Encoder* encoder : encoders) {
+    for (Encoder* encoder : encoders)
       delete encoder;
-    }
 
     encoders[encoderRaw] = new TimedRawEncoder(conn);
     encoders[encoderRRE] = new TimedRREEncoder(conn);
@@ -33,7 +32,7 @@ namespace suite {
 
     for (uint i = 0; i < encoders.size(); i++) {
       timedEncoders[static_cast<EncoderClass>(i)] = 
-              dynamic_cast<TimedEncoder*>(encoders[i]);
+                    dynamic_cast<TimedEncoder*>(encoders[i]);
     }
   }
 
@@ -41,9 +40,8 @@ namespace suite {
                                          : EncodeManager(conn),
                                            SINGLE_ENCODER(true)
   {
-    for (Encoder* e : encoders) {
+    for (Encoder* e : encoders)
       delete e;
-    }
 
     EncoderClass encoderClass = settings.encoderClass;
     TimedEncoder* timedEncoder = constructTimedEncoder(encoderClass, conn);
@@ -98,7 +96,7 @@ namespace suite {
 
   std::map<EncoderClass, encoderStats> Manager::stats() {
     std::map<EncoderClass, encoderStats> stats;
-    for(auto const& encoder : timedEncoders) {
+    for (auto const& encoder : timedEncoders) {
       if (encoder.second->stats().writeRectEncodetime ||
           encoder.second->stats().writeSolidRectEncodetime)
           stats[encoder.first] = encoder.second->stats();

--- a/tests/suite/Manager.cxx
+++ b/tests/suite/Manager.cxx
@@ -89,11 +89,11 @@ namespace suite {
     // We keep track of the time it takes to encode an entire frame,
     // and how much time there is left until the next frame occurs
     // (as it was recorded).
-    frameData data {
+    writeUpdateStats data {
       .timeRequired = frameTime,
       .timeSpent = (uint) (time.count() * 10e3),
     };
-    timedEncoder_->addFrameData(data);
+    timedEncoder_->addWriteUpdate(data);
   }
 
   std::map<EncoderClass, encoderStats> Manager::stats() {

--- a/tests/suite/Manager.h
+++ b/tests/suite/Manager.h
@@ -68,10 +68,19 @@ namespace suite {
       Manager(class rfb::SConnection *conn, EncoderSettings settings);
       ~Manager();
 
+      void writeUpdate(const rfb::UpdateInfo& ui, const rfb::PixelBuffer* pb,
+                       const rfb::RenderedCursor* renderedCursor);
+
+      void writeUpdate(const rfb::UpdateInfo& ui, const rfb::PixelBuffer* pb,
+                       const rfb::RenderedCursor* renderedCursor,
+                       uint frameTime);
+
       std::map<EncoderClass, encoderStats> stats();
     protected:
       std::map<EncoderClass, TimedEncoder*> timedEncoders;
       const bool SINGLE_ENCODER;
+    private:
+      TimedEncoder* timedEncoder_;
     };
 }
 #endif // __SUITE_MANAGER_H__

--- a/tests/suite/Manager.h
+++ b/tests/suite/Manager.h
@@ -40,20 +40,20 @@ namespace suite {
   inline std::string encodingToString(const int encoding)
   {
     switch (encoding) {
-      case rfb::encodingRaw:
-        return "Raw";
-      case rfb::encodingCopyRect:
-        return "CopyRect";
-      case rfb::encodingRRE:
-         return "RRE";
-      case rfb::encodingCoRRE:
-        return "CoRRE";
-      case rfb::encodingHextile:
-        return "Hextile";
-      case rfb::encodingTight:
-        return "Tight";
-      case rfb::encodingZRLE:
-        return "ZRLE";
+    case rfb::encodingRaw:
+      return "Raw";
+    case rfb::encodingCopyRect:
+      return "CopyRect";
+    case rfb::encodingRRE:
+        return "RRE";
+    case rfb::encodingCoRRE:
+      return "CoRRE";
+    case rfb::encodingHextile:
+      return "Hextile";
+    case rfb::encodingTight:
+      return "Tight";
+    case rfb::encodingZRLE:
+      return "ZRLE";
     }
     return std::to_string(encoding);
   }

--- a/tests/suite/Manager.h
+++ b/tests/suite/Manager.h
@@ -4,6 +4,7 @@
 #include "rfb/EncodeManager.h"
 #include "rfb/SConnection.h"
 #include "rfb/encodings.h"
+#include "codec/timed/encoderStats.h"
 #include <map>
 #include <stdexcept>
 #include <string>

--- a/tests/suite/Server.cxx
+++ b/tests/suite/Server.cxx
@@ -44,7 +44,7 @@ namespace suite {
     delete pb;
   }
 
-  void Server::loadImage(Image *image, int x, int y)
+  void Server::loadImage(const Image *image, int x, int y)
   {
     rfb::Rect rect(x,y, x + image->width, y + image->height);
     int stride;

--- a/tests/suite/Server.cxx
+++ b/tests/suite/Server.cxx
@@ -57,7 +57,7 @@ namespace suite {
     updates.add_changed(rect);
     updates.getUpdateInfo(&ui, changed);
 
-    writeUpdate(ui, pb);
+    manager->writeUpdate(ui, pb, NULL, image->frameTime);
   }
 
   void Server::writeUpdate(const rfb::UpdateInfo& ui,

--- a/tests/suite/Server.h
+++ b/tests/suite/Server.h
@@ -36,7 +36,7 @@ namespace suite {
       virtual void setDesktopSize(int fb_width, int fb_height,
                                   const rfb::ScreenSet& layout);
       // Loads an Image onto the framebuffer at x, y
-      virtual void loadImage(Image* image, int x = 0, int y = 0);
+      virtual void loadImage(const Image* image, int x = 0, int y = 0);
 
       std::map<EncoderClass, encoderStats> stats();
     public:

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -10,7 +10,6 @@
 #include <ios>
 #include <stdexcept>
 #include <sys/stat.h>
-#include <iomanip>
 
 using namespace suite;
 
@@ -110,61 +109,9 @@ void Benchmark::runBenchmark(EncoderSettings* settings, size_t len)
     if(!encoderStats.size())
       continue; // FIXME: throw/log error?
 
-    int tableWidth = 35;
-    int precision = 5;
     for(const auto& es : encoderStats) {
        struct encoderStats stats = es.second;
-
-        // FIXME: Wrap this monstrosity in smaller functions :^)
-        std::cout << "\n\t" << stats.name << " encoder: (seconds)\n\t\t"
-                  << std::setprecision(precision) << std::fixed 
-                  << std::setw(tableWidth) << std::setfill(' ') << std::left
-                  << "writeRect: " << std::right << stats.writeRectEncodetime
-                  << "\n\t\t" << std::left  << std::setw(tableWidth)
-                  << "writeSolidRect: " << std::right 
-                  << stats.compressionRatioSolidRects()
-                  << "\n\t\t" << std::setw(tableWidth) << std::left
-                  << "total: " << std::right << stats.writeRectEncodetime 
-                                              + stats.writeSolidRectEncodetime
-                  << "\n\t\t" << std::setfill('-')
-                  << std::setw(tableWidth+precision+2)
-                  << std::left << "" << std::setfill(' ')
-                  << "\n\t\t" << std::setw(tableWidth) << std::left  
-                  << "# rects: " << std::right << stats.nRects
-                  << "\n\t\t" << std::setw(tableWidth) << std::left
-                  << "# solidRects: " << std::right << stats.nSolidRects 
-                  << "\n\t\t" << std::setfill('-') 
-                  << std::setw(tableWidth+precision+2)
-                  << std::left << "" << std::setfill(' ')
-                  << "\n\t\t" << std::setw(tableWidth) << std::left
-                  << "MPx/s (rects):" << std::right 
-                  << stats.megaPixelsPerSecondRects() << "\n\t\t"
-                  << std::setw(tableWidth) << std::left
-                  << "MPx/s (solidRects:)" << std::right 
-                  << stats.megaPixelsPerSecondSolidRects() << "\n\t\t"
-                  << std::setw(tableWidth) << std::left 
-                  << "MPx/s (combined)" << std::right
-                  << stats.megaPixelsPerSecondCombined() << "\n\t\t"
-                  << std::setfill('-') 
-                  << std::setw(tableWidth+precision+2)
-                  << std::left << "" << std::setfill(' ') << "\n\t\t"
-                  << std::setw(tableWidth) << std::left
-                  << "Compression ratio rects: "
-                  << stats.compressionRatioRects()
-                  << "\n\t\t" << std::setw(tableWidth) << std::left
-                  << "Compression ratio solidRects: " << std::right 
-                  << stats.compressionRatioSolidRects() << "\n\t\t"
-                  << std::setw(tableWidth) << std::left
-                  << "Compression ratio combined: " 
-                  << stats.compressionRatioCombined() << "\n\t\t"
-                  << std::setfill('-') << std::setw(tableWidth)
-                  << std::setw(tableWidth+precision+2)
-                  << std::left << "" << std::setfill(' ') << "\n\t\t"
-                  << std::setw(tableWidth) << std::left
-                  << "Score (time * compression ratio):" << std::right
-                  << stats.score() << "\n\t\t" << std::setfill('-') 
-                  << std::setw(tableWidth+precision+2)
-                  << std::left << "" << std::endl;
+       stats.print();
     }
   delete server;
   }

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -85,7 +85,7 @@ void Benchmark::runBenchmark(EncoderSettings* settings, size_t len)
 
   std::cout << "Starting benchmark using \"" << filename << "\"\n";
   while (file.peek() != EOF) {
-    Image* image = is.readImage(file);
+    const Image* image = is.readImage(file);
 
     // For each encoding we want to test, we load an image and loop through 
     // all servers

--- a/tests/suite/benchmark/Benchmark.cxx
+++ b/tests/suite/benchmark/Benchmark.cxx
@@ -84,7 +84,7 @@ void Benchmark::runBenchmark(EncoderSettings* settings, size_t len)
   }
 
   std::cout << "Starting benchmark using \"" << filename << "\"\n";
-  while(file.peek() != EOF) {
+  while (file.peek() != EOF) {
     Image* image = is.readImage(file);
 
     // For each encoding we want to test, we load an image and loop through 
@@ -100,16 +100,16 @@ void Benchmark::runBenchmark(EncoderSettings* settings, size_t len)
   std::cout << "Benchmarking complete!\n";
 
   // Loop through each server and print the corresponding statistics
-  for(auto &s : servers) {
+  for (auto &s : servers) {
     // FIXME: Refactor this to a separate function
     std::string encoderRequested = encoderClasstoString(s.first);
     Server* server = s.second;
     std::map<EncoderClass, encoderStats> encoderStats = server->stats();
 
-    if(!encoderStats.size())
+    if (!encoderStats.size())
       continue; // FIXME: throw/log error?
 
-    for(const auto& es : encoderStats) {
+    for (const auto& es : encoderStats) {
        struct encoderStats stats = es.second;
        stats.print();
     }
@@ -128,29 +128,29 @@ EncoderSettings Benchmark::encoderSettings(EncoderClass encoderClass,
     .compression = compression,
   };
 
-  switch(encoderClass) {
-      case encoderRaw:
-        settings.rfbEncoding = rfb::encodingRaw;
-        break;
-      case encoderRRE:
-        settings.rfbEncoding = rfb::encodingRRE;
-        break;
-      case encoderHextile:
-        settings.rfbEncoding = rfb::encodingHextile;
-        break;
-      case encoderTight:
-        settings.rfbEncoding = rfb::encodingTight;
-        break;
-      case encoderTightJPEG:
-        if (quality == NONE)
-          settings.quality = TWO;
-        settings.rfbEncoding = rfb::encodingTight;
-        break;
-      case encoderZRLE:
-        settings.rfbEncoding = rfb::encodingZRLE;
-        break;
-      default:
-        throw std::logic_error("EncoderClass not implemented");
+  switch (encoderClass) {
+  case encoderRaw:
+    settings.rfbEncoding = rfb::encodingRaw;
+    break;
+  case encoderRRE:
+    settings.rfbEncoding = rfb::encodingRRE;
+    break;
+  case encoderHextile:
+    settings.rfbEncoding = rfb::encodingHextile;
+    break;
+  case encoderTight:
+    settings.rfbEncoding = rfb::encodingTight;
+    break;
+  case encoderTightJPEG:
+    if (quality == NONE)
+      settings.quality = TWO;
+    settings.rfbEncoding = rfb::encodingTight;
+    break;
+  case encoderZRLE:
+    settings.rfbEncoding = rfb::encodingZRLE;
+    break;
+  default:
+    throw std::logic_error("EncoderClass not implemented");
   }
   return settings;
 }

--- a/tests/suite/benchmark/Benchmark.h
+++ b/tests/suite/benchmark/Benchmark.h
@@ -12,8 +12,8 @@ namespace suite {
   {
   public:
     Benchmark(std::string filename, const rdr::S32* e = encodings,
-                                    const size_t len = sizeof(encodings) /
-                                                       sizeof(*encodings));
+                                    const size_t len = sizeof(encodings)
+                                                     / sizeof(*encodings));
     ~Benchmark();
 
     // Runs decoding benchmark on the server.

--- a/tests/suite/codec/Image.cxx
+++ b/tests/suite/codec/Image.cxx
@@ -7,9 +7,10 @@
 namespace suite {
 
   Image::Image(int width, int height, rdr::U8* buffer,
-               int size, int x_offset, int y_offset)
+               int size, int x_offset, int y_offset, uint frameTime)
                 : width(width), height(height), x_offset(x_offset),
-                  y_offset(y_offset), size(size), buffer(buffer)
+                  y_offset(y_offset), size(size), frameTime(frameTime), 
+                  buffer(buffer)
   {
   }
 

--- a/tests/suite/codec/Image.cxx
+++ b/tests/suite/codec/Image.cxx
@@ -27,7 +27,7 @@ namespace suite {
     return *this;
   }
 
-  rdr::U8* Image::getBuffer()
+  rdr::U8* Image::getBuffer() const
   {
     return buffer;
   }

--- a/tests/suite/codec/Image.cxx
+++ b/tests/suite/codec/Image.cxx
@@ -8,9 +8,9 @@ namespace suite {
 
   Image::Image(int width, int height, rdr::U8* buffer,
                int size, int x_offset, int y_offset, uint frameTime)
-                : width(width), height(height), x_offset(x_offset),
-                  y_offset(y_offset), size(size), frameTime(frameTime), 
-                  buffer(buffer)
+             : width(width), height(height), x_offset(x_offset),
+               y_offset(y_offset), size(size), frameTime(frameTime), 
+               buffer(buffer)
   {
   }
 

--- a/tests/suite/codec/Image.h
+++ b/tests/suite/codec/Image.h
@@ -21,7 +21,7 @@ namespace suite {
           uint frameTime = 0);
     virtual ~Image();
     virtual Image& operator+=(Pixel const &pixel);
-    virtual rdr::U8* getBuffer();
+    virtual rdr::U8* getBuffer() const;
     const int width, height, x_offset, y_offset;
     uint size, frameTime;
     void setBuffer(rdr::U8 *buffer, int size);

--- a/tests/suite/codec/Image.h
+++ b/tests/suite/codec/Image.h
@@ -17,12 +17,13 @@ namespace suite {
   {
   public:
     Image(int width, int height, rdr::U8* buffer,
-          int size, int offset_x = 0, int offset_y = 0);
+          int size, int offset_x = 0, int offset_y = 0,
+          uint frameTime = 0);
     virtual ~Image();
     virtual Image& operator+=(Pixel const &pixel);
     virtual rdr::U8* getBuffer();
     const int width, height, x_offset, y_offset;
-    unsigned int size;
+    uint size, frameTime;
     void setBuffer(rdr::U8 *buffer, int size);
   private:
     rdr::U8* buffer;

--- a/tests/suite/codec/ImageDecoder.h
+++ b/tests/suite/codec/ImageDecoder.h
@@ -48,10 +48,10 @@ namespace suite {
                                          int size, int x_offest = 0,
                                          int y_offset = 0) = 0;
     virtual void encodeImageTofile(const rdr::U8* data, int width, int height,
-                                                    std::string filename) = 0;
+                                   std::string filename) = 0;
     virtual Image* encodeImageToMemory(const rdr::U8* data, int width,
-                                      int height, int offset_x = 0,
-                                      int offset_y  = 0) = 0;
+                                       int height, int offset_x = 0,
+                                       int offset_y  = 0) = 0;
     const decoderEnum type;
     const std::string name;
   protected:

--- a/tests/suite/codec/PNGDecoder.cxx
+++ b/tests/suite/codec/PNGDecoder.cxx
@@ -30,7 +30,7 @@ namespace suite {
     int height;
     int channels;
 
-    rdr::U8* data = (rdr::U8*)stbi_load(filename.c_str(), &width, &height,
+    rdr::U8* data = (rdr::U8*) stbi_load(filename.c_str(), &width, &height,
                                         &channels, 0);
     int bufSize = width * height * channels;
 
@@ -102,7 +102,7 @@ namespace suite {
     int bufSize = width * height * 4;
     rdr::U8* paddedBuf = new rdr::U8[bufSize];
 
-    for(int i = 0; i < bufSize; i += 4) {
+    for (int i = 0; i < bufSize; i += 4) {
       paddedBuf[i] = data[i]; 
       paddedBuf[i + 1] = data[i+1]; 
       paddedBuf[i + 2] = data[i+2]; 

--- a/tests/suite/codec/PNGDecoder.h
+++ b/tests/suite/codec/PNGDecoder.h
@@ -12,15 +12,15 @@ namespace suite {
 
     Image *decodeImageFromFile(std::string filename);
     Image* decodeImageFromMemory(rdr::U8* data, int width, int height,
-                                          int size,
-                                          int x_offset = 0,
-                                          int y_offset = 0);
+                                 int size,
+                                 int x_offset = 0,
+                                 int y_offset = 0);
 
     void encodeImageTofile(const rdr::U8* data, int width,
-                            int height, std::string filename);
+                           int height, std::string filename);
 
     Image* encodeImageToMemory(const rdr::U8* data, int width, int height,
-                                int x_offset = 0, int y_offset = 0);
+                               int x_offset = 0, int y_offset = 0);
   private:
     // Sets all bits in alpha channel to 255
     rdr::U8* addAlphaPadding(const rdr::U8* data, int width, int height);

--- a/tests/suite/codec/QOIDecoder.cxx
+++ b/tests/suite/codec/QOIDecoder.cxx
@@ -17,7 +17,7 @@ namespace suite {
  Image* QOIDecoder::decodeImageFromFile(std::string filename)
  {
   qoi_desc desc;
-  rdr::U8* data = (rdr::U8*)qoi_read(filename.c_str(), &desc, 4);
+  rdr::U8* data = (rdr::U8*) qoi_read(filename.c_str(), &desc, 4);
 
   if (!data)
     throw std::ios_base::failure("qoi: error decoding image");
@@ -29,25 +29,25 @@ namespace suite {
  }
 
 Image* QOIDecoder::decodeImageFromMemory(rdr::U8* data, int width, int height,
-                                          int size, int x_offset, int y_offset)
+                                         int size, int x_offset, int y_offset)
 {
   qoi_desc desc;
-  rdr::U8* decodedImage = (rdr::U8*)qoi_decode(data, size, &desc, 4);
+  rdr::U8* decodedImage = (rdr::U8*) qoi_decode(data, size, &desc, 4);
   if (decodedImage == NULL)
     throw std::ios_base::failure("qoi: error decoding image");
 
   int bufSize = desc.width * desc.height * desc.channels;
   Image* image = new Image(width, height, decodedImage, bufSize,
-                            x_offset, y_offset);
+                           x_offset, y_offset);
   measurePixelRate(width, height, desc.channels);
   return image;
 }
  void QOIDecoder::encodeImageTofile(const rdr::U8 *data, int width, int height,
                                     std::string filename)
  {
-  qoi_desc desc{
-    .width = (unsigned int)width,
-    .height = (unsigned int)height,
+  qoi_desc desc {
+    .width = (unsigned int) width,
+    .height = (unsigned int) height,
     .channels = 4,
     .colorspace = QOI_SRGB
   };
@@ -63,7 +63,7 @@ Image* QOIDecoder::decodeImageFromMemory(rdr::U8* data, int width, int height,
  Image* QOIDecoder::encodeImageToMemory(const rdr::U8 *data, int width,
                                         int height, int x_offset, int y_offset)
  {
-  qoi_desc desc{
+  qoi_desc desc {
     .width = (unsigned int)width,
     .height = (unsigned int)height,
     .channels = 4,
@@ -71,7 +71,7 @@ Image* QOIDecoder::decodeImageFromMemory(rdr::U8* data, int width, int height,
   };
 
   int size;
-  rdr::U8* encodedData = (rdr::U8*)qoi_encode(data, &desc,  &size);
+  rdr::U8* encodedData = (rdr::U8*) qoi_encode(data, &desc,  &size);
   if (!encodedData)
     throw std::ios_base::failure("error encoding image");
   Image* image = new Image(desc.width, desc.height, encodedData,

--- a/tests/suite/codec/QOIDecoder.h
+++ b/tests/suite/codec/QOIDecoder.h
@@ -13,14 +13,14 @@ namespace suite {
 
     Image *decodeImageFromFile(std::string filename);
     Image* decodeImageFromMemory(rdr::U8* data, int width, int height,
-                                          int size, int x_offest = 0,
-                                          int y_offset = 0);
+                                 int size, int x_offest = 0,
+                                 int y_offset = 0);
 
     void encodeImageTofile(const rdr::U8* data, int width, int height,
-                            std::string filename);
+                           std::string filename);
 
     Image* encodeImageToMemory(const rdr::U8* data, int width, int height,
-                                  int x_offset = 0, int y_offset = 0);
+                               int x_offset = 0, int y_offset = 0);
   };
 }
 #endif // __SUITE_QOI_DECODER_H__

--- a/tests/suite/codec/decoderFactory.cxx
+++ b/tests/suite/codec/decoderFactory.cxx
@@ -6,13 +6,13 @@
 namespace suite {
   ImageDecoder* constructDecoder(decoderEnum decoder)
   {
-  switch (decoder) {
+    switch (decoder) {
     case PPM:
-      return (ImageDecoder*)new PPMDecoder();
+      return (ImageDecoder*) new PPMDecoder();
     case PNG:
-      return (ImageDecoder*)new PNGDecoder();
+      return (ImageDecoder*) new PNGDecoder();
     case QOI:
-      return (ImageDecoder*)new QOIDecoder();
+      return (ImageDecoder*) new QOIDecoder();
     default:
       throw std::logic_error("decoder not imlpemented");
     }

--- a/tests/suite/codec/timed/TimedEncoder.cxx
+++ b/tests/suite/codec/timed/TimedEncoder.cxx
@@ -3,6 +3,7 @@
 #include "rfb/PixelBuffer.h"
 #include "rfb/SConnection.h"
 #include "../../Manager.h"
+#include "../../Server.h"
 #include <chrono>
 
 namespace suite {
@@ -83,5 +84,10 @@ namespace suite {
     // & reset our MemOutStream
     conn_->setStreams(is, os);
     encoderOutstream->clear();
+  }
+
+  void TimedEncoder::addFrameData(frameData data)
+  {
+    stats_.framesData.push_back(data);
   }
 }

--- a/tests/suite/codec/timed/TimedEncoder.cxx
+++ b/tests/suite/codec/timed/TimedEncoder.cxx
@@ -1,4 +1,5 @@
 #include "TimedEncoder.h"
+#include "encoderStats.h"
 #include "rdr/MemOutStream.h"
 #include "rfb/PixelBuffer.h"
 #include "rfb/SConnection.h"
@@ -9,7 +10,8 @@
 namespace suite {
 
   TimedEncoder::TimedEncoder(EncoderClass encoderclass) 
-                           : encoderClass(encoderclass)
+                           : encoderClass(encoderclass),
+                             currentWriteUpdate(0)
   {
     stats_ = encoderStats{ 
       .writeRectEncodetime = 0,
@@ -55,6 +57,13 @@ namespace suite {
     stats_.outputSizeRects += encoderOutstream->length();
     stats_.nRects++;
 
+    // Keep track of rects belonging to the same writeUpdate().
+    writeRectStats stats {
+      .timeSpent = time.count(),
+      .pixelCount = pb->width() * pb->height(),
+    };
+    stats_.writeUpdates[currentWriteUpdate].writeRects.push_back(stats);
+
     // Return the original OutStream after encoding
     // & reset our MemOutStream
     conn_->setStreams(is, os);
@@ -80,6 +89,13 @@ namespace suite {
     stats_.inputSizeSolidRects += width * height * 4;
     stats_.outputSizeSolidRects += encoderOutstream->length();
     stats_.nSolidRects++;
+
+    // Keep track of rects belonging to the same writeUpdate().
+    writeRectStats stats {
+      .timeSpent = time.count(),
+      .pixelCount = width * height,
+    };
+    stats_.writeUpdates[currentWriteUpdate].writeSolidRects.push_back(stats);
 
     // Return the original OutStream after encoding
     // & reset our MemOutStream

--- a/tests/suite/codec/timed/TimedEncoder.cxx
+++ b/tests/suite/codec/timed/TimedEncoder.cxx
@@ -86,7 +86,7 @@ namespace suite {
     encoderOutstream->clear();
   }
 
-  void TimedEncoder::addFrameData(frameData data)
+  void TimedEncoder::addWriteUpdate(writeUpdateStats data)
   {
     stats_.framesData.push_back(data);
   }

--- a/tests/suite/codec/timed/TimedEncoder.cxx
+++ b/tests/suite/codec/timed/TimedEncoder.cxx
@@ -20,6 +20,7 @@ namespace suite {
       .outputSizeSolidRects = 0,
       .nRects = 0,
       .nSolidRects = 0,
+      .delayedFrames = 0,
       .name = encoderClassName(encoderclass),
       };
     // Use an OutStream and inject it to the underlying 
@@ -88,6 +89,7 @@ namespace suite {
 
   void TimedEncoder::addWriteUpdate(writeUpdateStats data)
   {
+    stats_.delayedFrames += !data.encodedInTime();
     stats_.framesData.push_back(data);
   }
 }

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -87,7 +87,7 @@ namespace suite {
     virtual void writeSolidRect(int width, int height,
                                 const rfb::PixelFormat& pf,
                                 const rdr::U8* colour)=0;
-    void addFrameData(frameData data);
+    void addWriteUpdate(writeUpdateStats data);
   private:
     rdr::MemOutStream *encoderOutstream;
     rdr::OutStream* os;

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -42,7 +42,8 @@ namespace suite {
 
     struct EncoderSettings {
       EncoderClass encoderClass;
-      int rfbEncoding;
+      int *rfbEncoding;
+      size_t encodingSize;
       PseudoEncodingLevel quality;
       PseudoEncodingLevel compression;
     };

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -7,6 +7,7 @@
 #include "rfb/Encoder.h"
 #include "rfb/PixelBuffer.h"
 #include "rfb/SConnection.h"
+#include "encoderStats.h"
 #include <chrono>
 #include <stdexcept>
 #include <string>
@@ -67,66 +68,6 @@ namespace suite {
     }
   }
   using namespace enumEncoder;
-
-  struct frameData
-  {
-    uint timeRequired;
-    uint timeSpent;
-  };
-
-
-  struct encoderStats {
-    double writeRectEncodetime;
-    double writeSolidRectEncodetime;
-    int inputSizeRects;
-    int outputSizeRects;
-    int inputSizeSolidRects;
-    int outputSizeSolidRects;
-    int nRects;
-    int nSolidRects;
-    std::string name;
-    std::vector<frameData> framesData;
-
-    double compressionRatioRects() 
-    {
-      return (double) outputSizeRects / inputSizeRects; 
-    }
-
-    double compressionRatioSolidRects()
-    {
-       return (double) outputSizeSolidRects / inputSizeSolidRects;
-    }
-
-    double compressionRatioCombined()
-    {
-      return (double) (outputSizeRects + outputSizeSolidRects)
-                    / (inputSizeRects + inputSizeSolidRects);
-    }
-
-    double megaPixelsPerSecondRects()
-    {
-      return inputSizeRects / (writeRectEncodetime * 10e6);
-    }
-  
-    double megaPixelsPerSecondSolidRects()
-    {
-      return inputSizeSolidRects / (writeSolidRectEncodetime * 10e6);
-    }
-
-    double megaPixelsPerSecondCombined()
-    {
-      return (inputSizeRects + inputSizeSolidRects) 
-           / ((writeRectEncodetime + writeSolidRectEncodetime) * 10e6);
-    }
-
-    // Returns a "score" which is a function of time 
-    // per compressed data
-    double score()
-    {
-      return (writeRectEncodetime + writeSolidRectEncodetime)
-           * (compressionRatioCombined());
-    }
-  };
 
   class TimedEncoder
   {

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <string>
+#include <vector>
 namespace suite {
 
     // Copied from EncodeManager.cxx
@@ -67,6 +68,13 @@ namespace suite {
   }
   using namespace enumEncoder;
 
+  struct frameData
+  {
+    uint timeRequired;
+    uint timeSpent;
+  };
+
+
   struct encoderStats {
     double writeRectEncodetime;
     double writeSolidRectEncodetime;
@@ -77,6 +85,7 @@ namespace suite {
     int nRects;
     int nSolidRects;
     std::string name;
+    std::vector<frameData> framesData;
 
     double compressionRatioRects() 
     {
@@ -137,6 +146,7 @@ namespace suite {
     virtual void writeSolidRect(int width, int height,
                                 const rfb::PixelFormat& pf,
                                 const rdr::U8* colour)=0;
+    void addFrameData(frameData data);
   private:
     rdr::MemOutStream *encoderOutstream;
     rdr::OutStream* os;

--- a/tests/suite/codec/timed/TimedEncoder.h
+++ b/tests/suite/codec/timed/TimedEncoder.h
@@ -88,6 +88,7 @@ namespace suite {
                                 const rfb::PixelFormat& pf,
                                 const rdr::U8* colour)=0;
     void addWriteUpdate(writeUpdateStats data);
+    uint currentWriteUpdate;
   private:
     rdr::MemOutStream *encoderOutstream;
     rdr::OutStream* os;

--- a/tests/suite/codec/timed/TimedHextileEncoder.cxx
+++ b/tests/suite/codec/timed/TimedHextileEncoder.cxx
@@ -6,8 +6,8 @@
 namespace suite {
 
   TimedHextileEncoder::TimedHextileEncoder(SConnection* conn_) 
-                              : HextileEncoder(conn_), 
-                                TimedEncoder(encoderHextile)
+                                         : HextileEncoder(conn_),
+                                           TimedEncoder(encoderHextile)
   {
   }
 
@@ -16,7 +16,7 @@ namespace suite {
   }
 
   void TimedHextileEncoder::writeRect(const PixelBuffer* pb,
-                                    const Palette& palette)
+                                      const Palette& palette)
   {
     startWriteRectTimer(this->conn);
     HextileEncoder::writeRect(pb, palette);
@@ -24,8 +24,8 @@ namespace suite {
   }
 
   void TimedHextileEncoder::writeSolidRect(int width, int height,
-                                const PixelFormat& pf,
-                                const rdr::U8* colour)
+                                           const PixelFormat& pf,
+                                           const rdr::U8* colour)
   {
     startWriteSolidRectTimer(this->conn);
     HextileEncoder::writeSolidRect(width, height, pf, colour);

--- a/tests/suite/codec/timed/TimedRREEncoder.cxx
+++ b/tests/suite/codec/timed/TimedRREEncoder.cxx
@@ -6,8 +6,8 @@
 namespace suite {
 
   TimedRREEncoder::TimedRREEncoder(SConnection* conn_) 
-                                  : RREEncoder(conn_),
-                                    TimedEncoder(encoderRRE)
+                                 : RREEncoder(conn_),
+                                   TimedEncoder(encoderRRE)
   {
   }
 
@@ -16,7 +16,7 @@ namespace suite {
   }
 
   void TimedRREEncoder::writeRect(const PixelBuffer* pb,
-                                    const Palette& palette)
+                                  const Palette& palette)
   {
     startWriteRectTimer(this->conn);
     RREEncoder::writeRect(pb, palette);
@@ -24,8 +24,8 @@ namespace suite {
   }
 
   void TimedRREEncoder::writeSolidRect(int width, int height,
-                                const PixelFormat& pf,
-                                const rdr::U8* colour)
+                                       const PixelFormat& pf,
+                                       const rdr::U8* colour)
   {
     startWriteSolidRectTimer(this->conn);
     RREEncoder::writeSolidRect(width, height, pf, colour);

--- a/tests/suite/codec/timed/TimedRawEncoder.cxx
+++ b/tests/suite/codec/timed/TimedRawEncoder.cxx
@@ -15,7 +15,7 @@ namespace suite {
   }
 
   void TimedRawEncoder::writeRect(const PixelBuffer* pb,
-                                    const Palette& palette)
+                                  const Palette& palette)
   {
     startWriteRectTimer(this->conn);
     RawEncoder::writeRect(pb, palette);
@@ -23,8 +23,8 @@ namespace suite {
   }
 
   void TimedRawEncoder::writeSolidRect(int width, int height,
-                                const PixelFormat& pf,
-                                const rdr::U8* colour)
+                                       const PixelFormat& pf,
+                                       const rdr::U8* colour)
   {
     startWriteSolidRectTimer(this->conn);
     RawEncoder::writeSolidRect(width, height, pf, colour);

--- a/tests/suite/codec/timed/TimedTightEncoder.cxx
+++ b/tests/suite/codec/timed/TimedTightEncoder.cxx
@@ -9,8 +9,8 @@
 namespace suite {
 
   TimedTightEncoder::TimedTightEncoder(SConnection* conn_) 
-                                : TightEncoder(conn_), 
-                                  TimedEncoder(encoderTight)
+                                     : TightEncoder(conn_),
+                                       TimedEncoder(encoderTight)
   {
   }
 
@@ -27,8 +27,8 @@ namespace suite {
   }
 
   void TimedTightEncoder::writeSolidRect(int width, int height,
-                                const PixelFormat& pf,
-                                const rdr::U8* colour)
+                                         const PixelFormat& pf,
+                                         const rdr::U8* colour)
   {
     startWriteSolidRectTimer(this->conn);
     TightEncoder::writeSolidRect(width, height, pf, colour);

--- a/tests/suite/codec/timed/TimedTightJPEGEncoder.cxx
+++ b/tests/suite/codec/timed/TimedTightJPEGEncoder.cxx
@@ -6,8 +6,8 @@
 namespace suite {
 
   TimedTightJPEGEncoder::TimedTightJPEGEncoder(SConnection* conn_) 
-                            : TightJPEGEncoder(conn_), 
-                              TimedEncoder(encoderTightJPEG)
+                                             : TightJPEGEncoder(conn_),
+                                               TimedEncoder(encoderTightJPEG)
   {
   }
 
@@ -16,7 +16,7 @@ namespace suite {
   }
 
   void TimedTightJPEGEncoder::writeRect(const PixelBuffer* pb,
-                                    const Palette& palette)
+                                        const Palette& palette)
   {
     startWriteRectTimer(this->conn);
     TightJPEGEncoder::writeRect(pb, palette);
@@ -24,8 +24,8 @@ namespace suite {
   }
 
   void TimedTightJPEGEncoder::writeSolidRect(int width, int height,
-                                const PixelFormat& pf,
-                                const rdr::U8* colour)
+                                             const PixelFormat& pf,
+                                             const rdr::U8* colour)
   {
     startWriteSolidRectTimer(this->conn);
     TightJPEGEncoder::writeSolidRect(width, height, pf, colour);

--- a/tests/suite/codec/timed/TimedZRLEEncoder.cxx
+++ b/tests/suite/codec/timed/TimedZRLEEncoder.cxx
@@ -6,8 +6,8 @@
 namespace suite {
 
   TimedZRLEEncoder::TimedZRLEEncoder(SConnection* conn_) 
-                                  : ZRLEEncoder(conn_), 
-                                    TimedEncoder(encoderZRLE)
+                                   : ZRLEEncoder(conn_),
+                                     TimedEncoder(encoderZRLE)
   {
   }
 
@@ -16,7 +16,7 @@ namespace suite {
   }
 
   void TimedZRLEEncoder::writeRect(const PixelBuffer* pb,
-                                    const Palette& palette)
+                                   const Palette& palette)
   {
     startWriteRectTimer(this->conn);
     ZRLEEncoder::writeRect(pb, palette);
@@ -24,8 +24,8 @@ namespace suite {
   }
 
   void TimedZRLEEncoder::writeSolidRect(int width, int height,
-                                const PixelFormat& pf,
-                                const rdr::U8* colour)
+                                        const PixelFormat& pf,
+                                        const rdr::U8* colour)
   {
     startWriteSolidRectTimer(this->conn);
     ZRLEEncoder::writeSolidRect(width, height, pf, colour);

--- a/tests/suite/codec/timed/encoderStats.h
+++ b/tests/suite/codec/timed/encoderStats.h
@@ -13,7 +13,7 @@ namespace suite {
   struct writeUpdateStats
   {
     uint timeRequired;
-    uint timeSpent;
+    double timeSpent;
 
     // Was the frame encoded within the time budget?
     bool encodedInTime() const { return timeSpent <= timeRequired; }

--- a/tests/suite/codec/timed/encoderStats.h
+++ b/tests/suite/codec/timed/encoderStats.h
@@ -26,6 +26,7 @@ namespace suite {
     int nSolidRects;
     std::string name;
     std::vector<frameData> framesData;
+    static const int BPP = 4;
 
     double compressionRatioRects() 
     {
@@ -45,18 +46,18 @@ namespace suite {
 
     double megaPixelsPerSecondRects()
     {
-      return inputSizeRects / (writeRectEncodetime * 10e6);
+      return inputSizeRects / (writeRectEncodetime * 10e6 * BPP);
     }
   
     double megaPixelsPerSecondSolidRects()
     {
-      return inputSizeSolidRects / (writeSolidRectEncodetime * 10e6);
+      return inputSizeSolidRects / (writeSolidRectEncodetime * 10e6 * BPP);
     }
 
     double megaPixelsPerSecondCombined()
     {
       return (inputSizeRects + inputSizeSolidRects) 
-           / ((writeRectEncodetime + writeSolidRectEncodetime) * 10e6);
+           / ((writeRectEncodetime + writeSolidRectEncodetime) * 10e6 * BPP);
     }
 
     // Returns a "score" which is a function of time 

--- a/tests/suite/codec/timed/encoderStats.h
+++ b/tests/suite/codec/timed/encoderStats.h
@@ -33,6 +33,7 @@ namespace suite {
     int outputSizeSolidRects;
     int nRects;
     int nSolidRects;
+    double delayedFrames;
     std::string name;
     std::vector<writeUpdateStats> framesData;
     static const int BPP = 4;
@@ -75,6 +76,11 @@ namespace suite {
     {
       return (writeRectEncodetime + writeSolidRectEncodetime)
            * (compressionRatioCombined());
+    }
+
+    double delayedFramesRatio()
+    {
+      return delayedFrames * 100 / framesData.size();
     }
   
   private:

--- a/tests/suite/codec/timed/encoderStats.h
+++ b/tests/suite/codec/timed/encoderStats.h
@@ -1,0 +1,69 @@
+#ifndef __SUITE_ENCODERSTATS_H__
+#define __SUITE_ENCODERSTATS_H__
+
+#include <string>
+#include <vector>
+
+namespace suite {
+
+  struct frameData
+  {
+    uint timeRequired;
+    uint timeSpent;
+  };
+
+  struct encoderStats {
+
+    double writeRectEncodetime;
+    double writeSolidRectEncodetime;
+    int inputSizeRects;
+    int outputSizeRects;
+    int inputSizeSolidRects;
+    int outputSizeSolidRects;
+    int nRects;
+    int nSolidRects;
+    std::string name;
+    std::vector<frameData> framesData;
+
+    double compressionRatioRects() 
+    {
+      return (double) outputSizeRects / inputSizeRects; 
+    }
+
+    double compressionRatioSolidRects()
+    {
+       return (double) outputSizeSolidRects / inputSizeSolidRects;
+    }
+
+    double compressionRatioCombined()
+    {
+      return (double) (outputSizeRects + outputSizeSolidRects)
+                    / (inputSizeRects + inputSizeSolidRects);
+    }
+
+    double megaPixelsPerSecondRects()
+    {
+      return inputSizeRects / (writeRectEncodetime * 10e6);
+    }
+  
+    double megaPixelsPerSecondSolidRects()
+    {
+      return inputSizeSolidRects / (writeSolidRectEncodetime * 10e6);
+    }
+
+    double megaPixelsPerSecondCombined()
+    {
+      return (inputSizeRects + inputSizeSolidRects) 
+           / ((writeRectEncodetime + writeSolidRectEncodetime) * 10e6);
+    }
+
+    // Returns a "score" which is a function of time 
+    // per compressed data
+    double score()
+    {
+      return (writeRectEncodetime + writeSolidRectEncodetime)
+           * (compressionRatioCombined());
+    }
+  };
+}
+#endif // __SUITE_ENCODERSTATS_H__

--- a/tests/suite/codec/timed/encoderStats.h
+++ b/tests/suite/codec/timed/encoderStats.h
@@ -10,7 +10,7 @@
 
 namespace suite {
 
-  struct frameData
+  struct writeUpdateStats
   {
     uint timeRequired;
     uint timeSpent;
@@ -34,7 +34,7 @@ namespace suite {
     int nRects;
     int nSolidRects;
     std::string name;
-    std::vector<frameData> framesData;
+    std::vector<writeUpdateStats> framesData;
     static const int BPP = 4;
 
     double compressionRatioRects() 
@@ -84,32 +84,32 @@ namespace suite {
 
     double medianTimeSpent()
     {
-      return medianFrameDataValue([](const frameData& lhs,
-                                     const frameData& rhs) {
+      return medianFrameDataValue([](const writeUpdateStats& lhs,
+                                     const writeUpdateStats& rhs) {
         return lhs.timeSpent < rhs.timeSpent;
       });
     }
 
     double medianTimeRequired()
     {
-      return medianFrameDataValue([](const frameData& lhs,
-                                     const frameData& rhs) {
+      return medianFrameDataValue([](const writeUpdateStats& lhs,
+                                     const writeUpdateStats& rhs) {
         return lhs.timeRequired < rhs.timeRequired;
       });
     }
 
     double medianEncodingtime()
     {
-      return medianFrameDataValue([](const frameData& lhs,
-                                     const frameData& rhs) {
+      return medianFrameDataValue([](const writeUpdateStats& lhs,
+                                     const writeUpdateStats& rhs) {
         return lhs.encodingMargin() < rhs.encodingMargin();
       });
     }
 
-    double medianFrameDataValue(bool comparator(const frameData& lhs,
-                                                const frameData& rhs))
+    double medianFrameDataValue(bool comparator(const writeUpdateStats& lhs,
+                                                const writeUpdateStats& rhs))
     {
-      std::vector<frameData> copy = framesData;
+      std::vector<writeUpdateStats> copy = framesData;
       std::nth_element(copy.begin(), copy.begin() + 1, copy.end(), comparator);
       return copy[(int) (copy.size() / 2)].timeSpent;
     }
@@ -117,27 +117,27 @@ namespace suite {
 
     double meanTimeSpent()
     {
-      std::vector<frameData> copy = framesData;
+      std::vector<writeUpdateStats> copy = framesData;
       double sum = 0;
-      for(frameData& f : framesData)
+      for(writeUpdateStats& f : framesData)
         sum += f.timeSpent;
       return sum / copy.size();
     }
 
     double meanTimeRequired()
     {
-      std::vector<frameData> copy = framesData;
+      std::vector<writeUpdateStats> copy = framesData;
       double sum = 0;
-      for(frameData& f : framesData)
+      for(writeUpdateStats& f : framesData)
         sum += f.timeRequired;
       return sum / copy.size();
     }
 
     double meanEncodingMargin()
     {
-      std::vector<frameData> copy = framesData;
+      std::vector<writeUpdateStats> copy = framesData;
       double sum = 0;
-      for(frameData& f : framesData)
+      for(writeUpdateStats& f : framesData)
         sum += f.encodingMargin();
       return sum / copy.size();
     }
@@ -145,7 +145,7 @@ namespace suite {
     double varianceTimeSpent()
     {
       const double mean = meanTimeSpent();
-      std::vector<frameData> copy = framesData;
+      std::vector<writeUpdateStats> copy = framesData;
       const int size = copy.size();
       double variance = 0;
       for(int i = 0; i < size; i++) 
@@ -160,7 +160,7 @@ namespace suite {
     double varianceTimeRequired()
     {
       const double mean = meanTimeRequired();
-      std::vector<frameData> copy = framesData;
+      std::vector<writeUpdateStats> copy = framesData;
       const int size = copy.size();
       double variance = 0;
       for(int i = 0; i < size; i++) 
@@ -174,7 +174,7 @@ namespace suite {
     double varianceEncodingMargin()
     {
       const double mean = meanEncodingMargin();
-      std::vector<frameData> copy = framesData;
+      std::vector<writeUpdateStats> copy = framesData;
       const int size = copy.size();
       double variance = 0;
       for(int i = 0; i < size; i++) 
@@ -189,7 +189,7 @@ namespace suite {
     double stdTimeRequired() { return std::sqrt(varianceTimeRequired()); }
     double stdEncodingMargin() { return std::sqrt(varianceEncodingMargin()); }
 
-    // frameData statistics functions end //
+    // writeUpdateStats functions end //
 
   public:
     void print()

--- a/tests/suite/codec/timed/encoderStats.h
+++ b/tests/suite/codec/timed/encoderStats.h
@@ -117,39 +117,35 @@ namespace suite {
 
     double meanTimeSpent()
     {
-      std::vector<writeUpdateStats> copy = framesData;
       double sum = 0;
       for(writeUpdateStats& f : framesData)
         sum += f.timeSpent;
-      return sum / copy.size();
+      return sum / framesData.size();
     }
 
     double meanTimeRequired()
     {
-      std::vector<writeUpdateStats> copy = framesData;
       double sum = 0;
       for(writeUpdateStats& f : framesData)
         sum += f.timeRequired;
-      return sum / copy.size();
+      return sum / framesData.size();
     }
 
     double meanEncodingMargin()
     {
-      std::vector<writeUpdateStats> copy = framesData;
       double sum = 0;
       for(writeUpdateStats& f : framesData)
         sum += f.encodingMargin();
-      return sum / copy.size();
+      return sum / framesData.size();
     }
 
     double varianceTimeSpent()
     {
       const double mean = meanTimeSpent();
-      std::vector<writeUpdateStats> copy = framesData;
-      const int size = copy.size();
+      const int size = framesData.size();
       double variance = 0;
       for(int i = 0; i < size; i++) 
-        variance += (copy[i].timeSpent - mean) * (copy[i].timeSpent - mean);
+        variance += (framesData[i].timeSpent - mean) * (framesData[i].timeSpent - mean);
 
       // divide by N-1 for unbiased variance
       // https://en.wikipedia.org/wiki/Bessel%27s_correction
@@ -160,12 +156,11 @@ namespace suite {
     double varianceTimeRequired()
     {
       const double mean = meanTimeRequired();
-      std::vector<writeUpdateStats> copy = framesData;
-      const int size = copy.size();
+      const int size = framesData.size();
       double variance = 0;
       for(int i = 0; i < size; i++) 
-        variance += (copy[i].timeRequired - mean)
-                  * (copy[i].timeRequired - mean);
+        variance += (framesData[i].timeRequired - mean)
+                  * (framesData[i].timeRequired - mean);
 
       variance /= (size - 1); 
       return variance;
@@ -174,12 +169,11 @@ namespace suite {
     double varianceEncodingMargin()
     {
       const double mean = meanEncodingMargin();
-      std::vector<writeUpdateStats> copy = framesData;
-      const int size = copy.size();
+      const int size = framesData.size();
       double variance = 0;
       for(int i = 0; i < size; i++) 
-        variance += (copy[i].encodingMargin() - mean)
-                  * (copy[i].encodingMargin() - mean);
+        variance += (framesData[i].encodingMargin() - mean)
+                  * (framesData[i].encodingMargin() - mean);
 
       variance /= (size - 1); 
       return variance;

--- a/tests/suite/codec/timed/encoderStats.h
+++ b/tests/suite/codec/timed/encoderStats.h
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <vector>
+#include <iomanip>
+#include <iostream>
 
 namespace suite {
 
@@ -63,6 +65,61 @@ namespace suite {
     {
       return (writeRectEncodetime + writeSolidRectEncodetime)
            * (compressionRatioCombined());
+    }
+
+    void print()
+    {
+      int tableWidth = 35;
+      int precision = 5;
+      std::cout << "\n\t" << name << " encoder: (seconds)\n\t\t"
+                << std::setprecision(precision) << std::fixed 
+                << std::setw(tableWidth) << std::setfill(' ') << std::left
+                << "writeRect: " << std::right << writeRectEncodetime
+                << "\n\t\t" << std::left  << std::setw(tableWidth)
+                << "writeSolidRect: " << std::right 
+                << compressionRatioSolidRects()
+                << "\n\t\t" << std::setw(tableWidth) << std::left
+                << "total: " << std::right << writeRectEncodetime 
+                                            + writeSolidRectEncodetime
+                << "\n\t\t" << std::setfill('-')
+                << std::setw(tableWidth+precision+2)
+                << std::left << "" << std::setfill(' ')
+                << "\n\t\t" << std::setw(tableWidth) << std::left  
+                << "# rects: " << std::right << nRects
+                << "\n\t\t" << std::setw(tableWidth) << std::left
+                << "# solidRects: " << std::right << nSolidRects 
+                << "\n\t\t" << std::setfill('-') 
+                << std::setw(tableWidth+precision+2)
+                << std::left << "" << std::setfill(' ')
+                << "\n\t\t" << std::setw(tableWidth) << std::left
+                << "MPx/s (rects):" << std::right 
+                << megaPixelsPerSecondRects() << "\n\t\t"
+                << std::setw(tableWidth) << std::left
+                << "MPx/s (solidRects:)" << std::right 
+                << megaPixelsPerSecondSolidRects() << "\n\t\t"
+                << std::setw(tableWidth) << std::left 
+                << "MPx/s (combined)" << std::right
+                << megaPixelsPerSecondCombined() << "\n\t\t"
+                << std::setfill('-') 
+                << std::setw(tableWidth+precision+2)
+                << std::left << "" << std::setfill(' ') << "\n\t\t"
+                << std::setw(tableWidth) << std::left
+                << "Compression ratio rects: "
+                << compressionRatioRects()
+                << "\n\t\t" << std::setw(tableWidth) << std::left
+                << "Compression ratio solidRects: " << std::right 
+                << compressionRatioSolidRects() << "\n\t\t"
+                << std::setw(tableWidth) << std::left
+                << "Compression ratio combined: " 
+                << compressionRatioCombined() << "\n\t\t"
+                << std::setfill('-') << std::setw(tableWidth)
+                << std::setw(tableWidth+precision+2)
+                << std::left << "" << std::setfill(' ') << "\n\t\t"
+                << std::setw(tableWidth) << std::left
+                << "Score (time * compression ratio):" << std::right
+                << score() << "\n\t\t" << std::setfill('-') 
+                << std::setw(tableWidth+precision+2)
+                << std::left << "" << std::endl;
     }
   };
 }

--- a/tests/suite/codec/timed/timedEncoderFactory.cxx
+++ b/tests/suite/codec/timed/timedEncoderFactory.cxx
@@ -9,23 +9,24 @@
 #include <stdexcept>
 
 namespace suite {
-  TimedEncoder* constructTimedEncoder(EncoderClass encoder, rfb::SConnection* sconn)
+  TimedEncoder* constructTimedEncoder(EncoderClass encoder,
+                                      rfb::SConnection* sconn)
   {
     switch(encoder) {
-      case encoderRaw:
-        return new TimedRawEncoder(sconn);
-      case encoderRRE:
-        return new TimedRREEncoder(sconn);
-      case encoderHextile:
-        return new TimedHextileEncoder(sconn);
-      case encoderTight:
-        return new TimedTightEncoder(sconn);
-      case encoderTightJPEG:
-        return new TimedTightJPEGEncoder(sconn);
-      case encoderZRLE:
-        return new TimedZRLEEncoder(sconn);
-      default:
-        throw std::logic_error("decoder not implemented");
+    case encoderRaw:
+      return new TimedRawEncoder(sconn);
+    case encoderRRE:
+      return new TimedRREEncoder(sconn);
+    case encoderHextile:
+      return new TimedHextileEncoder(sconn);
+    case encoderTight:
+      return new TimedTightEncoder(sconn);
+    case encoderTightJPEG:
+      return new TimedTightJPEGEncoder(sconn);
+    case encoderZRLE:
+      return new TimedZRLEEncoder(sconn);
+    default:
+      throw std::logic_error("decoder not implemented");
     }
   }
 }

--- a/tests/suite/codec/timed/timedEncoderFactory.h
+++ b/tests/suite/codec/timed/timedEncoderFactory.h
@@ -5,7 +5,8 @@
 #include "rfb/SConnection.h"
 
 namespace suite {
-  TimedEncoder* constructTimedEncoder(EncoderClass encoder, rfb::SConnection* conn);
+  TimedEncoder* constructTimedEncoder(EncoderClass encoder,
+                                      rfb::SConnection* conn);
 }
 
 #endif // __SUITE_TIMEDENCODERFACTORY_H__

--- a/tests/suite/io/FrameInStream.cxx
+++ b/tests/suite/io/FrameInStream.cxx
@@ -39,7 +39,7 @@ namespace suite {
     Image* image = decoder->decodeImageFromMemory(data, width, height, size,
                                                   x_offset, y_offset);
     delete [] data;
-
+    image->frameTime = frameTime;
     return image;
   }
 

--- a/tests/suite/io/FrameOutStream.cxx
+++ b/tests/suite/io/FrameOutStream.cxx
@@ -6,7 +6,7 @@
 namespace suite {
 
   FrameOutStream::FrameOutStream(std::string filename, ImageDecoder* decoder)
-                                : headerWritten(false), decoder(decoder->name)
+                               : headerWritten(false), decoder(decoder->name)
   {
     file.open(filename.c_str());
     if (!file.is_open())

--- a/tests/suite/io/FrameOutStream.h
+++ b/tests/suite/io/FrameOutStream.h
@@ -53,7 +53,7 @@ namespace suite {
 
     void addUpdate(ImageUpdate* update);
     void addUpdate(rdr::U8* data, int width, int height, int x_offset, 
-                  int y_offset, int size);
+                   int y_offset, int size);
                   
     void writeHeader(int width, int height);
   private:

--- a/tests/suite/recorder/Recorder.cxx
+++ b/tests/suite/recorder/Recorder.cxx
@@ -2,6 +2,9 @@
 #include "../../unix/x0vncserver/XPixelBuffer.h"
 #include "tx/TXWindow.h"
 #include <X11/Xlib.h>
+#include <sys/select.h>
+#include <chrono>
+#include <thread>
 
 namespace suite {
 
@@ -66,6 +69,13 @@ namespace suite {
       if (events.size()) {
         handleEvents(events);
       }
+
+        // Sleep to reduce CPU usage when idle
+        struct timespec timespec;
+        timespec.tv_sec = 0;
+        timespec.tv_nsec = 1;
+        if (pselect(0, 0, 0, 0, &timespec, 0) < 0)
+          std::abort();
     }
   }
 

--- a/tests/suite/recorder/Recorder.cxx
+++ b/tests/suite/recorder/Recorder.cxx
@@ -9,7 +9,7 @@
 namespace suite {
 
   Recorder::Recorder(std::string filename, ImageDecoder* decoder,
-                    std::string display) : decoder(decoder)
+                     std::string display) : decoder(decoder)
   {
     // XOpenDisplay takes ownership of display string,
     // so we need to make a copy.
@@ -29,7 +29,7 @@ namespace suite {
     fs = new FrameOutStream(filename, decoder);
 
     int xdamageErrorBase;
-    if(!XDamageQueryExtension(dpy, &xdamageEventBase, &xdamageErrorBase)) {
+    if (!XDamageQueryExtension(dpy, &xdamageEventBase, &xdamageErrorBase)) {
       std::cerr << "DAMAGE extension not present" << std::endl;
       exit(1);
     }
@@ -82,7 +82,7 @@ namespace suite {
   void Recorder::handleEvents(std::vector<XEvent>& events)
   {
     rfb::Rect damagedRect;
-    for(XEvent event : events) {
+    for (XEvent event : events) {
       if (event.type == xdamageEventBase) {
         XDamageNotifyEvent* dev;
         rfb::Rect rect;
@@ -107,9 +107,9 @@ namespace suite {
 
     // Save changed rectangle
     suite::Image* image = decoder->encodeImageToMemory(data, 
-                                                        width, height,
-                                                        damagedRect.tl.x,
-                                                        damagedRect.tl.y);
+                                                       width, height,
+                                                       damagedRect.tl.x,
+                                                       damagedRect.tl.y);
     suite::ImageUpdate* update = new suite::ImageUpdate(image);
     fs->addUpdate(update);
     delete update;

--- a/tests/suite/recorder/record.cxx
+++ b/tests/suite/recorder/record.cxx
@@ -9,9 +9,9 @@ int main(int argc, char* argv[])
   if(argc < 3) {
 
     std::string decoderString;
-    std::for_each(decodersMap.begin(), decodersMap.end(), [&](const auto &s){
+    std::for_each(decodersMap.begin(), decodersMap.end(), [&](const auto &s) {
       decoderString += s.first + " ";
-  });
+    });
     std::cerr << "Error, incorrect arguments\n" 
               << "Usage:\n\t"
               << argv[0] << " <X display> <output filename> " 

--- a/tests/suite/suite.cxx
+++ b/tests/suite/suite.cxx
@@ -18,7 +18,7 @@ int main(int argc, char** argv)
 
   Benchmark *b;
   try {
-   b = new Benchmark(filename);
+    b = new Benchmark(filename);
   } catch (rfb::Exception &e) {
     std::cerr << "Error: " << e.str() << std::endl;
     exit(1);


### PR DESCRIPTION
Keep track of individual data points instead of taking averages over the entire run. This way we can print things like mean, median, min, max, variance etc.